### PR TITLE
Use global timeout setting for jest

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 exports.HOME_DIR = '/home/seluser'
 exports.CHROME_DEFAULT_PATH = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-exports.DEFAULT_JEST_TIMEOUT = 60 * 1000 // 1min
+exports.DEFAULT_JEST_TIMEOUT = 60 // 1min
 
 const LOG_DIR = '/var/log/cont'
 exports.LOG_FILES = [

--- a/src/jest.setup.js
+++ b/src/jest.setup.js
@@ -6,7 +6,9 @@ const playwright = require('playwright')
 const { CHROME_DEFAULT_PATH, DEFAULT_JEST_TIMEOUT, SUPPORTED_BROWSER, LAUNCH_ARGS } = require('./constants')
 const { logHelper } = require('./utils')
 
-jest.setTimeout(process.env.JEST_TIMEOUT || DEFAULT_JEST_TIMEOUT)
+const testTimeout = (parseInt(process.env.TEST_TIMEOUT) || DEFAULT_JEST_TIMEOUT)
+process.stdout.write(`Setting test timeout to ${testTimeout}sec\n\n`);
+jest.setTimeout(testTimeout * 1000)
 
 global.logs = []
 


### PR DESCRIPTION
Using our newly introduced TEST_TIMEOUT env var, allows the test timeout to be controlled via `saucectl run --timeout <sec>`. This creates feature parity between puppeteer and playwright in terms of saucectl.