### PR TITLE
Update playwright to 1.3.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,8 @@
 ./*.js
 ./*.json
 !package.json
+!package-lock.json
 node_modules
-package-lock.json
 .git
 Dockerfile.base
 Dockerfile.saucectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ ENV PATH="/home/seluser/bin:/home/seluser/.nvm/versions/node/v${NODE_VERSION}/bi
 WORKDIR /home/seluser
 
 COPY package.json .
-RUN npm install
+COPY package-lock.json .
+RUN npm ci
 
 # Playwright caches the downloaded browser by default in ~/.cache/ms-playwright
 # However, running the container in CI may result in a different active user and therefore home folder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,11 +918,26 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
     },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "ajv": {
@@ -2268,19 +2283,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2508,9 +2510,9 @@
       }
     },
     "extract-zip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
-      "integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -2965,18 +2967,18 @@
       }
     },
     "https-proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
+        "agent-base": "6",
+        "debug": "4"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -3969,9 +3971,9 @@
       }
     },
     "jpeg-js": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-      "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4725,22 +4727,14 @@
       }
     },
     "playwright": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.0.2.tgz",
-      "integrity": "sha512-92qvTeQ45Wex7wRwxqFZQm7lV8j7Z+Dxs7mNUS9wtlGS9mXswp1903XV1r7lKlvvaZ89uqV2BuZN+UUDpBaIAQ==",
-      "requires": {
-        "playwright-core": "=1.0.2"
-      }
-    },
-    "playwright-core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.0.2.tgz",
-      "integrity": "sha512-JYTygH/jJ4/wpIy+owSMnEQb8BjbQptWqpED6smwEmccijL2B74KZg92V93rdmJxc4lNuS4iLR6SG3RQbBW2Aw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.3.0.tgz",
+      "integrity": "sha512-W3mwXv2XNFugbepSZTZxI314WfI1SAjdZBEeGOu8S5KnPz4RSlunUFgXn6496o8lobPmORLcJ9VTSGyiFfGpaw==",
       "requires": {
         "debug": "^4.1.1",
         "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^3.0.0",
-        "jpeg-js": "^0.3.7",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.0",
         "mime": "^2.4.4",
         "pngjs": "^5.0.0",
         "progress": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jest": "^26.4.2",
     "jest-circus": "^26.4.2",
     "jest-cli": "^26.4.2",
-    "playwright": "^1.0.0",
+    "playwright": "1.3.0",
     "saucelabs": "^4.4.0",
     "shelljs": "^0.8.3",
     "webdriverio": "^5.21.0",


### PR DESCRIPTION
Update playwright to version 1.3.0.

This fixes a newly introduced issue that occurred after updating jest:
```
    TypeError: domain.enter is not a function

      at Connection.dispatch (node_modules/playwright/lib/client/connection.js:107:25)
      at Immediate.<anonymous> (node_modules/playwright/lib/inprocess.js:39:85)
```

The issue seems to re-surface in playwright 1.4.0, hence why I'm skipping over that one for now (a fix is announced for 1.4.1).