### PR TITLE
enhancements: Package a template project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo ::set-output name=version::${VERSION}
       - name: Update Release version
-        run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yaml
+        run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yml
       - name: Archive template
         run: tar --strip-components 1 -czf saucetpl.tar.gz .saucetpl
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Update Release version
         run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yml
       - name: Archive template
-        run: tar --strip-components 1 -czf saucetpl.tar.gz .saucetpl
+        run: tar --strip-components=1 -czf saucetpl.tar.gz .saucetpl
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.prep.outputs.version }}/assets?name=saucetpl.tar.gz
+          upload_url: https://uploads.github.com/repos/saucelabs/sauce-playwright-runner/releases/${{ steps.prep.outputs.version }}/assets?name=saucetpl.tar.gz
           asset_path: ./saucetpl.tar.gz
           asset_name: saucetpl.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,23 @@ jobs:
         run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yaml
       - name: Archive template
         run: tar --strip-components 1 -czf saucetpl.tar.gz .saucetpl
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.prep.outputs.version }}
+          release_name: Release ${{ steps.prep.outputs.version }}
+          body: Release ${{ steps.prep.outputs.version }}
+          draft: false
       - name: Upload Template Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/saucelabs/sauce-playwright-runner/releases/${{ steps.prep.outputs.version }}/assets?name=saucetpl.tar.gz
+          upload_url: https://uploads.github.com/repos/saucelabs/sauce-playwright-runner/releases/${{ steps.create_release.outputs.id }}/assets?name=saucetpl.tar.gz
           asset_path: ./saucetpl.tar.gz
           asset_name: saucetpl.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,28 @@ jobs:
           tags: |
             saucelabs/stt-playwright-jest-node:latest
             saucelabs/stt-playwright-jest-node:${{ steps.prep.outputs.version }}
+
+  release-template-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo ::set-output name=version::${VERSION}
+      - name: Update Release version
+        run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yaml
+      - name: Archive template
+        run: tar --strip-components 1 -czf saucetpl.tar.gz .saucetpl
+      - name: Upload Template Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://uploads.github.com/repos/saucelabs/sauce-cypress-runner/releases/${{ steps.prep.outputs.version }}/assets?name=saucetpl.tar.gz
+          asset_path: ./saucetpl.tar.gz
+          asset_name: saucetpl.tar.gz
+          asset_content_type: application/tar+gzip

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,6 @@ dist
 /*.js
 !jest.config.js
 tests/fixtures/typescript/
-.sauce/
+/.sauce/
 
 run.yaml

--- a/.saucetpl/.sauce/config.yml
+++ b/.saucetpl/.sauce/config.yml
@@ -1,0 +1,18 @@
+apiVersion: v1alpha
+metadata:
+  name: Feature XYZ
+  tags:
+    - e2e
+    - release team
+    - other tag
+  build: Release $CI_COMMIT_SHORT_SHA
+files:
+  - tests/example.test.js
+suites:
+  - name: "saucy test"
+    match: ".*.(spec|test).js$"
+image:
+  base: saucelabs/stt-playwright-jest-node
+  version: ##VERSION##
+sauce:
+  region: us-west-1

--- a/.saucetpl/tests/example.test.js
+++ b/.saucetpl/tests/example.test.js
@@ -1,0 +1,6 @@
+describe('saucectl demo test', () => {
+	test('should verify title of the page', async () => {
+		await page.goto('https://www.saucedemo.com/');
+		expect(await page.title()).toBe('Swag Labs');
+	});
+});


### PR DESCRIPTION
## Proposed changes

This PR adds (during release process) the generation of a **[saucectl](https://github.com/saucelabs/saucectl)** template to be used when initiating a new project.

It will add, to each release, a `saucetpl.tar.gz` that will contains:
- Default configuration for this runner
- An example file

Elements can be added simply by adding files/contents into the `.saucetpl` folder.

## Requirements

**GITHUB_TOKEN** needs to be added to secrets in order to be able to push assets to the release.