### PR TITLE
Check for existing release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,12 @@ jobs:
         run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yml
       - name: Archive template
         run: cd .saucetpl && tar -czf ../saucetpl.tar.gz .
+      - name: Check if release exists
+        id: check_release
+        run: echo ::set-output name=success::$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/saucelabs/sauce-playwright-runner/releases/tags/${{ steps.prep.outputs.version }})
       - name: Create Release
         id: create_release
+        if: steps.check_release.outputs.success != '200'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
During the release process, the release can be manually created.
This PR is here to avoid failing when it's already existing.