### PR TITLE
fix: Ensure Playwright exitCode is propagated up to saucectl 

### DIFF
--- a/src/jest-recorder.js
+++ b/src/jest-recorder.js
@@ -18,10 +18,10 @@ const jestRecorder = () => {
     child.stdout.pipe(ws);
     child.stderr.pipe(ws);
 
-    child.on('exit', (exitCode) => ws.end(() => {
+    child.on('exit', (exitCode) => {
         fs.closeSync(fd);
         process.exit(exitCode);
-    }));
+    });
 };
 
 exports.jestRecorder = jestRecorder;


### PR DESCRIPTION
## Proposed changes

Restore expected `exitCode` to be non-zero when some tests are failing.
Relates: https://github.com/saucelabs/testrunner-toolkit/issues/63

![render1604439835563](https://user-images.githubusercontent.com/11074879/98043981-02fb5080-1ddb-11eb-9ae4-1424824c2fc4.gif)

### Considerations

It's not optimum since `stream.Writable` is not cleanly closed before file being closed. As soon as operations are maid on stream either `ws.end()` or waiting for `stream.finished()`, `exitCode` resets to 0 and npm is not failing as expected.

Log are still saved completely, cf. https://app.saucelabs.com/tests/59f897817c7441ee804be3b16801729c