### PR TITLE
Add function to create job via global data store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,19 +89,6 @@ RUN npm ci --production
 # That's why we let Playwright know where the location actually is.
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/seluser/.cache/ms-playwright
 
-#==================
-# Install saucectl
-#==================
-ARG SAUCECTL_VERSION=0.20.0
-ENV SAUCECTL_BINARY=saucectl_${SAUCECTL_VERSION}_linux_64-bit.tar.gz
-RUN curl -L -o ${SAUCECTL_BINARY} \
-  -H "Accept: application/octet-stream" \
-  https://github.com/saucelabs/saucectl/releases/download/v${SAUCECTL_VERSION}/${SAUCECTL_BINARY} \
-  && tar -xvzf ${SAUCECTL_BINARY} \
-  && mkdir /home/seluser/bin/ \
-  && mv ./saucectl /home/seluser/bin/saucectl \
-  && rm ${SAUCECTL_BINARY}
-
 COPY --chown=seluser:seluser . .
 
 # Workaround for permissions in CI if run with a different user

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/home/seluser/.cache/ms-playwright
 #==================
 # Install saucectl
 #==================
-ARG SAUCECTL_VERSION=0.16.0
+ARG SAUCECTL_VERSION=0.20.0
 ENV SAUCECTL_BINARY=saucectl_${SAUCECTL_VERSION}_linux_64-bit.tar.gz
 RUN curl -L -o ${SAUCECTL_BINARY} \
   -H "Accept: application/octet-stream" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1022,24 +1022,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.0.tgz",
       "integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA=="
     },
-    "@types/puppeteer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-3.0.2.tgz",
-      "integrity": "sha512-JRuHPSbHZBadOxxFwpyZPeRlpPTTeMbQneMdpFd8LXdyNfFSiX950CGewdm69g/ipzEAXAmMyFF1WOWJOL/nKw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/puppeteer-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-2.0.0.tgz",
-      "integrity": "sha512-JvoEb7KgEkUet009ZDrtpUER3hheXoHgQByuYpJZ5WWT7LWwMH+0NTqGQXGgoOKzs+G5NA1T4DZwXK79Bhnejw==",
-      "dev": true,
-      "requires": {
-        "@types/puppeteer": "*"
-      }
-    },
     "@types/request": {
       "version": "2.48.5",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
@@ -1243,9 +1225,9 @@
       }
     },
     "arch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="
     },
     "archive-type": {
       "version": "4.0.0",
@@ -1630,13 +1612,6 @@
         "bin-version": "^3.0.0",
         "semver": "^5.6.0",
         "semver-truncate": "^1.1.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
       }
     },
     "bin-wrapper": {
@@ -1653,9 +1628,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -2552,6 +2527,11 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -3115,11 +3095,6 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -6193,19 +6168,34 @@
       }
     },
     "saucelabs": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.4.0.tgz",
-      "integrity": "sha512-qSIIi1uSt++aaqhehLNmVbmSzjEsZj+pNlua6YpK0UChKLlyXSXNCMsmSSA9hfzD+PrAWQMNYGrikOQvGUrtrw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.6.0.tgz",
+      "integrity": "sha512-GAytkfq2QTVzwMS4/A99YQ79wqZvq29hO1r7+JYvfExRD9UipuvzvqhzsAfS8fKg+OuRIbIDTk0Rd7aWXa06zw==",
       "requires": {
         "bin-wrapper": "^4.1.0",
         "change-case": "^4.1.1",
         "form-data": "^3.0.0",
-        "got": "^11.1.4",
+        "got": "^11.7.0",
         "hash.js": "^1.1.7",
         "tunnel": "0.0.6",
-        "yargs": "^15.3.1"
+        "yargs": "^16.0.3"
       },
       "dependencies": {
+        "@sindresorhus/is": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ=="
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
         "form-data": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -6215,6 +6205,72 @@
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
+        },
+        "got": {
+          "version": "11.8.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.0.tgz",
+          "integrity": "sha512-k9noyoIIY9EejuhaBNLyZ31D5328LeqnyPNXJQb2XlJZcKakLqN5m6O/ikhq/0lw56kUYS54fVm+D1x57YC9oQ==",
+          "requires": {
+            "@sindresorhus/is": "^4.0.0",
+            "@szmarczak/http-timer": "^4.0.5",
+            "@types/cacheable-request": "^6.0.1",
+            "@types/responselike": "^1.0.0",
+            "cacheable-lookup": "^5.0.3",
+            "cacheable-request": "^7.0.1",
+            "decompress-response": "^6.0.0",
+            "http2-wrapper": "^1.0.0-beta.5.2",
+            "lowercase-keys": "^2.0.0",
+            "p-cancelable": "^2.0.0",
+            "responselike": "^2.0.0"
+          }
+        },
+        "http2-wrapper": {
+          "version": "1.0.0-beta.5.2",
+          "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
+          "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+          "requires": {
+            "quick-lru": "^5.1.1",
+            "resolve-alpn": "^1.0.0"
+          }
+        },
+        "quick-lru": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+        },
+        "yargs": {
+          "version": "16.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.1.tgz",
+          "integrity": "sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
         }
       }
     },
@@ -6227,21 +6283,11 @@
       }
     },
     "seek-bzip": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+      "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
       "requires": {
-        "commander": "~2.8.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        }
+        "commander": "^2.8.1"
       }
     },
     "semver": {
@@ -6260,13 +6306,6 @@
       "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "requires": {
         "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
       }
     },
     "sentence-case": {
@@ -6831,9 +6870,9 @@
       }
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jest-circus": "^26.4.2",
     "jest-cli": "^26.4.2",
     "playwright": "^1.4.1",
-    "saucelabs": "^4.4.0",
+    "saucelabs": "^4.6.0",
     "shelljs": "^0.8.3",
     "webdriverio": "^5.21.0",
     "js-yaml": "3.14.0"

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -37,36 +37,36 @@ for (const match of buildMatches) {
 // Keep these pieces of code for future integration.
 const createJobShell = async (tags, api) => {
     const body = {
-        'name': jobName,
-        'acl': [
+        name: jobName,
+        acl: [
           {
-            'type': 'username',
-            'value': process.env.SAUCE_USERNAME
+            type: 'username',
+            value: process.env.SAUCE_USERNAME
           }
         ],
-        //'start_time': startTime,
-        //'end_time': endTime,
-        'source': 'vdc', // will use devx
-        'platform': 'webdriver', // will use playwright
-        'status': 'complete',
-        'live': false,
-        'metadata': {},
-        'tags': tags,
-        'attributes': {
-            'container': false,
-            'browser': DESIRED_BROWSER,
-            'browser_version': '*',
-            'commands_not_successful': 1, // to be removed
-            'devx': true,
-            'os': 'test', // need collect
-            'performance_enabled': 'true', // to be removed
-            'public': 'team',
-            'record_logs': true, // to be removed
-            'record_mp4': 'true', // to be removed
-            'record_screenshots': 'true', // to be removed
-            'record_video': 'true', // to be removed
-            'video_url': 'test', // remove
-            'log_url': 'test' // remove
+        //'start_time: startTime,
+        //'end_time: endTime,
+        source: 'vdc', // will use devx
+        platform: 'webdriver', // will use playwright
+        status: 'complete',
+        live: false,
+        metadata: {},
+        tags: tags,
+        attributes: {
+            container: false,
+            browser: DESIRED_BROWSER,
+            browser_version: '*',
+            commands_not_successful: 1, // to be removed
+            devx: true,
+            os: 'test', // need collect
+            performance_enabled: 'true', // to be removed
+            public: 'team',
+            record_logs: true, // to be removed
+            record_mp4: 'true', // to be removed
+            record_screenshots: 'true', // to be removed
+            record_video: 'true', // to be removed
+            video_url: 'test', // remove
+            log_url: 'test' // remove
         }
     };
     
@@ -82,7 +82,7 @@ const createJobShell = async (tags, api) => {
       )
     ]);
   
-    return sessionId;
+    return sessionId || 0;
 };
 
 const createjobLegacy = async (tags, api) => {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -8,6 +8,7 @@ const { remote } = require('webdriverio')
 
 const { exec } = require('./utils')
 const { LOG_FILES, HOME_DIR, DESIRED_BROWSER } = require('./constants')
+const { create } = require('domain')
 
 const log = logger('reporter')
 
@@ -32,52 +33,112 @@ for (const match of buildMatches) {
     build = build.replace(match, replacement || '')
 }
 
+const createJobShell = async (tags, api) => {
+    const body = {
+        'name': jobName,
+        'acl': [
+          {
+            'type': 'username',
+            'value': process.env.SAUCE_USERNAME
+          }
+        ],
+        //'start_time': startTime,
+        //'end_time': endTime,
+        'source': 'vdc', // will use devx
+        'platform': 'webdriver', // will use playwright
+        'status': 'complete',
+        'live': false,
+        'metadata': {},
+        'tags': tags,
+        'attributes': {
+          'container': false,
+          'browser': DESIRED_BROWSER,
+          'browser_version': '*',
+          'commands_not_successful': 1, // to be removed
+          'devx': true,
+          'os': 'test', // need collect
+          'performance_enabled': 'true', // to be removed
+          'public': 'team',
+          'record_logs': true, // to be removed
+          'record_mp4': 'true', // to be removed
+          'record_screenshots': 'true', // to be removed
+          'record_video': 'true', // to be removed
+          'video_url': 'test', // remove
+          'log_url': 'test' // remove
+        }
+      };
+    
+      let sessionId;
+      await Promise.all([
+        api.createResultJob(
+          body
+        ).then(
+          (resp) => {
+            sessionId = resp.id;
+          },
+          (e) => console.error('Create job failed: ', e.stack)
+        )
+      ]);
+    
+      if (undefined === sessionId || 0 === sessionId) {
+        return 0;
+      }
+    
+      return sessionId;
+};
+
+const createjobLegacy = async (tags, api) => {
+    /**
+     * don't try to create a job if no credentials are set
+     */
+    if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+        return
+    }
+
+    /**
+     * create a job shell by trying to initialise a session with
+     * invalid capabilities
+     * ToDo(Christian): remove once own testrunner job API is available
+     */
+    await remote({
+        user: process.env.SAUCE_USERNAME,
+        key: process.env.SAUCE_ACCESS_KEY,
+        region: region,
+        connectionRetryCount: 0,
+        logLevel: 'silent',
+        capabilities: {
+            browserName: DESIRED_BROWSER,
+            platformName: '*',
+            browserVersion: '*',
+            'sauce:options': {
+                devX: true,
+                name: jobName,
+                tags: tags,
+                build
+            }
+        }
+    }).catch((err) => err)
+
+    const { jobs } = await api.listJobs(
+        process.env.SAUCE_USERNAME,
+        { limit: 1, full: true, name: jobName }
+    )
+    return jobs && jobs.length && jobs[0].id;
+};
+
 module.exports = class TestrunnerReporter {
     constructor () {
+        let tags = process.env.SAUCE_TAGS
+        if (tags) {
+            tags = tags.split(",")
+        }
+
         log.info('Create job shell')
-        this.sessionId = (async () => {
-            /**
-             * don't try to create a job if no credentials are set
-             */
-            if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
-                return
-            }
-
-            let tags = process.env.SAUCE_TAGS
-            if (tags) {
-                tags = tags.split(",")
-            }
-
-            /**
-             * create a job shell by trying to initialise a session with
-             * invalid capabilities
-             * ToDo(Christian): remove once own testrunner job API is available
-             */
-            await remote({
-                user: process.env.SAUCE_USERNAME,
-                key: process.env.SAUCE_ACCESS_KEY,
-                region: region,
-                connectionRetryCount: 0,
-                logLevel: 'silent',
-                capabilities: {
-                    browserName: DESIRED_BROWSER,
-                    platformName: '*',
-                    browserVersion: '*',
-                    'sauce:options': {
-                        devX: true,
-                        name: jobName,
-                        tags: tags,
-                        build
-                    }
-                }
-            }).catch((err) => err)
-
-            const { jobs } = await api.listJobs(
-                process.env.SAUCE_USERNAME,
-                { limit: 1, full: true, name: jobName }
-            )
-            return jobs && jobs.length && jobs[0].id
-        })()
+        if (process.env.ENABLE_PLATFORM === 'true') {
+            this.sessionId = createJobShell(tags, api);
+        } else {
+            this.sessionId = createjobLegacy(tags, api)
+        }
     }
 
     async onRunStart () {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -151,7 +151,7 @@ module.exports = class TestrunnerReporter {
          * only upload assets if a session was initiated before
          */
 
-        if (!sessionId || 0 === sessionId) {
+        if (!sessionId) {
             return
         }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -32,6 +32,9 @@ for (const match of buildMatches) {
     build = build.replace(match, replacement || '')
 }
 
+// NOTE: this function is not available currently.
+// It will be ready once data store API actually works.
+// Keep these pieces of code for future integration.
 const createJobShell = async (tags, api) => {
     const body = {
         'name': jobName,

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -8,7 +8,6 @@ const { remote } = require('webdriverio')
 
 const { exec } = require('./utils')
 const { LOG_FILES, HOME_DIR, DESIRED_BROWSER } = require('./constants')
-const { create } = require('domain')
 
 const log = logger('reporter')
 
@@ -51,40 +50,36 @@ const createJobShell = async (tags, api) => {
         'metadata': {},
         'tags': tags,
         'attributes': {
-          'container': false,
-          'browser': DESIRED_BROWSER,
-          'browser_version': '*',
-          'commands_not_successful': 1, // to be removed
-          'devx': true,
-          'os': 'test', // need collect
-          'performance_enabled': 'true', // to be removed
-          'public': 'team',
-          'record_logs': true, // to be removed
-          'record_mp4': 'true', // to be removed
-          'record_screenshots': 'true', // to be removed
-          'record_video': 'true', // to be removed
-          'video_url': 'test', // remove
-          'log_url': 'test' // remove
+            'container': false,
+            'browser': DESIRED_BROWSER,
+            'browser_version': '*',
+            'commands_not_successful': 1, // to be removed
+            'devx': true,
+            'os': 'test', // need collect
+            'performance_enabled': 'true', // to be removed
+            'public': 'team',
+            'record_logs': true, // to be removed
+            'record_mp4': 'true', // to be removed
+            'record_screenshots': 'true', // to be removed
+            'record_video': 'true', // to be removed
+            'video_url': 'test', // remove
+            'log_url': 'test' // remove
         }
-      };
+    };
     
-      let sessionId;
-      await Promise.all([
-        api.createResultJob(
-          body
-        ).then(
-          (resp) => {
-            sessionId = resp.id;
-          },
-          (e) => console.error('Create job failed: ', e.stack)
-        )
-      ]);
-    
-      if (undefined === sessionId || 0 === sessionId) {
-        return 0;
-      }
-    
-      return sessionId;
+    let sessionId;
+    await Promise.all([
+      api.createResultJob(
+        body
+      ).then(
+        (resp) => {
+          sessionId = resp.id;
+        },
+        (e) => console.error('Create job failed: ', e.stack)
+      )
+    ]);
+  
+    return sessionId;
 };
 
 const createjobLegacy = async (tags, api) => {
@@ -135,7 +130,7 @@ module.exports = class TestrunnerReporter {
 
         log.info('Create job shell')
         if (process.env.ENABLE_PLATFORM === 'true') {
-            this.sessionId = createJobShell(tags, api);
+            this.sessionId = createJobShell(tags, api)
         } else {
             this.sessionId = createjobLegacy(tags, api)
         }
@@ -155,7 +150,8 @@ module.exports = class TestrunnerReporter {
         /**
          * only upload assets if a session was initiated before
          */
-        if (!sessionId) {
+
+        if (!sessionId || 0 === sessionId) {
             return
         }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -132,7 +132,7 @@ module.exports = class TestrunnerReporter {
         }
 
         log.info('Create job shell')
-        if (process.env.ENABLE_PLATFORM === 'true') {
+        if (process.env.ENABLE_DATA_STORE) {
             this.sessionId = createJobShell(tags, api)
         } else {
             this.sessionId = createjobLegacy(tags, api)


### PR DESCRIPTION
Add function to create job via global data store. Currently both ways are existed and can be controlled by env var `ENABLE_DATA_STORE`.
Currently even with workable creating job part, the legacy uploading part cannot co-operate with it.