### PR TITLE
Create release with version sync'ed to playwright/playwright-test version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,31 @@ on:
       - 'v*.*.*'
 
 jobs:
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check that playwright version is synced
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          PLAYWRIGHT_VERSION_LOCKED=`< package-lock.json jq -r '.dependencies["playwright"].version'`
+          echo Comparing "v${VERSION}" with "v${PLAYWRIGHT_VERSION_LOCKED}"
+          if [ "v${PLAYWRIGHT_VERSION_LOCKED}" != "v${VERSION}" ]; then
+            exit 1
+          fi
+
+          TEST_VERSION=$(echo ${VERSION} | sed 's/\.//g')
+          PLAYWRIGHT_TEST_VERSION=`< package.json jq -r '.dependencies["@playwright/test"].version'`
+          PLAYWRIGHT_TEST_VERSION_LOCKED=`< package-lock.json jq -r '.dependencies["@playwright/test"].version'`
+
+          echo Comparing "v${TEST_VERSION}" with "v${PLAYWRIGHT_TEST_VERSION}" and "v${PLAYWRIGHT_TEST_VERSION_LOCKED}"
+          if [ "v${TEST_VERSION}" != "v${PLAYWRIGHT_TEST_VERSION}" ] || [ "v${PLAYWRIGHT_TEST_VERSION}" != "v${PLAYWRIGHT_TEST_VERSION_LOCKED}" ]; then
+            exit 1
+          fi
+          exit 0
   release-docker:
+    depends-on: version-consistency
     runs-on: ubuntu-latest
     steps:
       -
@@ -21,27 +45,28 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           echo ::set-output name=version::${VERSION}
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          context: .
-          file: ./Dockerfile
-          tags: |
-            saucelabs/stt-playwright-jest-node:latest
-            saucelabs/stt-playwright-jest-node:${{ steps.prep.outputs.version }}
-          build-args: |
-            BUILD_TAG=${{ steps.prep.outputs.version }}
+      # -
+      #   name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      # -
+      #   name: Build and push
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     context: .
+      #     file: ./Dockerfile
+      #     tags: |
+      #       saucelabs/stt-playwright-node:latest
+      #       saucelabs/stt-playwright-node:${{ steps.prep.outputs.version }}
+      #     build-args: |
+      #       BUILD_TAG=${{ steps.prep.outputs.version }}
 
   # TODO: Re-enable this once we start making playwright bundles
   release-windows-bundle:
+    depends-on: version-consistency
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -81,6 +106,7 @@ jobs:
           asset_name: sauce-playwright-win.zip
           asset_content_type: application/zip
   release-template-bundle:
+    depends-on: version-consistency
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fi
 
           TEST_VERSION=$(echo ${VERSION} | sed 's/\.//g')
-          PLAYWRIGHT_TEST_VERSION=`< package.json jq -r '.dependencies["@playwright/test"].version'`
+          PLAYWRIGHT_TEST_VERSION=`< package.json jq -r '.dependencies["@playwright/test"]'`
           PLAYWRIGHT_TEST_VERSION_LOCKED=`< package-lock.json jq -r '.dependencies["@playwright/test"].version'`
 
           echo Comparing "v${TEST_VERSION}" with "v${PLAYWRIGHT_TEST_VERSION}" and "v${PLAYWRIGHT_TEST_VERSION_LOCKED}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           fi
           exit 0
   release-docker:
-    depends-on: version-consistency
+    needs: version-consistency
     runs-on: ubuntu-latest
     steps:
       -
@@ -66,7 +66,7 @@ jobs:
 
   # TODO: Re-enable this once we start making playwright bundles
   release-windows-bundle:
-    depends-on: version-consistency
+    needs: version-consistency
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -106,7 +106,7 @@ jobs:
           asset_name: sauce-playwright-win.zip
           asset_content_type: application/zip
   release-template-bundle:
-    depends-on: version-consistency
+    needs: version-consistency
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
             exit 1
           fi
 
-          TEST_VERSION=$(echo ${VERSION} | sed 's/\.//g')
-          PLAYWRIGHT_TEST_VERSION=`< package.json jq -r '.dependencies["@playwright/test"]'`
-          PLAYWRIGHT_TEST_VERSION_LOCKED=`< package-lock.json jq -r '.dependencies["@playwright/test"].version'`
+          TEST_VERSION=0.$(echo ${VERSION} | sed 's/\.//g')
+          PLAYWRIGHT_TEST_VERSION=`< package.json jq -r '.dependencies["@playwright/test"]' | sed -E 's/\.[0-9]+$//'`
+          PLAYWRIGHT_TEST_VERSION_LOCKED=`< package-lock.json jq -r '.dependencies["@playwright/test"].version' | sed -E 's/\.[0-9]+$//'`
 
           echo Comparing "v${TEST_VERSION}" with "v${PLAYWRIGHT_TEST_VERSION}" and "v${PLAYWRIGHT_TEST_VERSION_LOCKED}"
           if [ "v${TEST_VERSION}" != "v${PLAYWRIGHT_TEST_VERSION}" ] || [ "v${PLAYWRIGHT_TEST_VERSION}" != "v${PLAYWRIGHT_TEST_VERSION_LOCKED}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,9 +120,11 @@ jobs:
         id: prep
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
+          NUM_VERSION=${GITHUB_REF#refs/tags/v}
           echo ::set-output name=version::${VERSION}
+          echo ::set-output name=num_version::${NUM_VERSION}
       - name: Update Release version
-        run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yml
+        run: sed -i "s/##VERSION##/${{ steps.prep.outputs.num_version }}/g" .saucetpl/.sauce/config.yml
       - name: Archive template
         run: cd .saucetpl && tar -czf ../saucetpl.tar.gz .
       - name: Check if release exists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,24 +45,24 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           echo ::set-output name=version::${VERSION}
-      # -
-      #   name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
-      # -
-      #   name: Build and push
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     push: true
-      #     context: .
-      #     file: ./Dockerfile
-      #     tags: |
-      #       saucelabs/stt-playwright-node:latest
-      #       saucelabs/stt-playwright-node:${{ steps.prep.outputs.version }}
-      #     build-args: |
-      #       BUILD_TAG=${{ steps.prep.outputs.version }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          tags: |
+            saucelabs/stt-playwright-node:latest
+            saucelabs/stt-playwright-node:${{ steps.prep.outputs.version }}
+          build-args: |
+            BUILD_TAG=${{ steps.prep.outputs.version }}
 
   # TODO: Re-enable this once we start making playwright bundles
   release-windows-bundle:
@@ -101,7 +101,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/saucelabs/sauce-playwright-runner/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=sauce-playwright-runner.zip
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.get_release_id.outputs.release_id }}/assets?name=sauce-playwright-runner.zip
           asset_path: ./sauce-playwright-win.zip
           asset_name: sauce-playwright-win.zip
           asset_content_type: application/zip

--- a/.saucetpl/.sauce/config.yml
+++ b/.saucetpl/.sauce/config.yml
@@ -1,18 +1,24 @@
 apiVersion: v1alpha
-metadata:
-  name: Feature XYZ
-  tags:
-    - e2e
-    - release team
-    - other tag
-  build: Release $CI_COMMIT_SHORT_SHA
-files:
-  - tests/example.test.js
-suites:
-  - name: "saucy test"
-    match: ".*.(spec|test).js$"
-image:
-  base: saucelabs/stt-playwright-jest-node
-  version: ##VERSION##
+kind: playwright
 sauce:
   region: us-west-1
+  concurrency: 1
+  metadata:
+    name: Testing Playwright Support
+    tags:
+      - e2e
+    build: "$BUILD_ID"
+playwright:
+  version: ##VERSION##
+  projectPath: tests/
+docker:
+  fileTransfer: mount
+suites:
+  - name: "saucy test"
+    platformName: "Windows 10"
+    testMatch: '**/*.js'
+
+    param:
+      browserName: "firefox"
+      headful: false
+      slowMo: 1000

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/saucelabs/testrunner-toolkit",
   "dependencies": {
-    "@playwright/test": "^0.171.0",
+    "@playwright/test": "0.171.0",
     "@wdio/logger": "^5.16.10",
     "find-process": "^1.4.3",
     "glob": "^7.1.6",


### PR DESCRIPTION
Same as Cypress, releases should now match the version of the underlying framework.

Dockerhub Repository create: https://hub.docker.com/r/saucelabs/stt-playwright-node
Example pipeline: https://github.com/FriggaHel/sauce-playwright-runner/actions/runs/510235150
Example release: https://github.com/FriggaHel/sauce-playwright-runner/releases/tag/v1.7.1