### PR TITLE
Docker: Store job details url in file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,9 @@ ENV IMAGE_NAME=saucelabs/stt-playwright-node
 ARG BUILD_TAG
 ENV IMAGE_TAG=${BUILD_TAG}
 
+# Let saucectl know where to read job details url
+LABEL com.saucelabs.job-details-url=/tmp/output-job-details-url
+
 #==================
 # ENTRYPOINT & CMD
 #==================

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ ARG BUILD_TAG
 ENV IMAGE_TAG=${BUILD_TAG}
 
 # Let saucectl know where to read job details url
-LABEL com.saucelabs.job-details-url=/tmp/output-job-details-url
+LABEL com.saucelabs.job-info=/tmp/output.json
 
 #==================
 # ENTRYPOINT & CMD

--- a/src/folio-runner.js
+++ b/src/folio-runner.js
@@ -187,7 +187,9 @@ async function run (nodeBin, runCfgPath, suiteName) {
 
     // Store file containing job-details url.
     // Path is similar to com.saucelabs.job-details-url LABEL in Dockerfile.
-    fs.writeFileSync('/tmp/output-job-details-url', jobDetailsUrl);
+    fs.writeFileSync('/tmp/output-job-details-url', JSON.stringify({
+      jobDetailsUrl
+    }));
 
     return hasPassed;
   } catch (e) {

--- a/src/folio-runner.js
+++ b/src/folio-runner.js
@@ -185,9 +185,9 @@ async function run (nodeBin, runCfgPath, suiteName) {
     const jobDetailsUrl = `https://app.${domain}/tests/${sessionId}`;
     console.log(`\nOpen job details page: ${jobDetailsUrl}\n`);
 
-    // Store file containing job-details url.
-    // Path is similar to com.saucelabs.job-details-url LABEL in Dockerfile.
-    fs.writeFileSync('/tmp/output-job-details-url', JSON.stringify({
+    // Store file containing details like job-details url.
+    // Path is similar to com.saucelabs.job-info LABEL in Dockerfile.
+    fs.writeFileSync('/tmp/output.json', JSON.stringify({
       jobDetailsUrl
     }));
 

--- a/src/folio-runner.js
+++ b/src/folio-runner.js
@@ -182,7 +182,13 @@ async function run (nodeBin, runCfgPath, suiteName) {
         domain = `${region}.saucelabs.com`;
     }
 
-    console.log(`\nOpen job details page: https://app.${domain}/tests/${sessionId}\n`);
+    const jobDetailsUrl = `https://app.${domain}/tests/${sessionId}`;
+    console.log(`\nOpen job details page: ${jobDetailsUrl}\n`);
+
+    // Store file containing job-details url.
+    // Path is similar to com.saucelabs.job-details-url LABEL in Dockerfile.
+    fs.writeFileSync('/tmp/output-job-details-url', jobDetailsUrl);
+
     return hasPassed;
   } catch (e) {
     console.error(`Could not complete job: '${e}'`);


### PR DESCRIPTION
In docker mode, store job detail URL in a file to allow saucectl to retrieve it.