### PR TITLE
Install node dependencies before trying to determine browser versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,16 @@ jobs:
           PLAYWRIGHT_VERSION=$(< package-lock.json jq -r '.dependencies["playwright"].version')
           echo "playwright_version=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
 
+      - name: Setup Node version
+        if: ${{ steps.prep.outputs.tag_name == '' }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Install dependencies
+        if: ${{ steps.prep.outputs.tag_name == '' }}
+        run: npm ci
+
       - name: Get Playwright browser versions
         run: |
           CHROMIUM_VERSION=$(node ./scripts/print-browser-version.js 'chromium')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,18 +58,18 @@ jobs:
           # Dependencies to launch webkit to inspect its version
           sudo apt-get update
           sudo apt-get install libegl1\
-                    libopus0\
-                    libwoff1\
-                    libharfbuzz-icu0\
-                    gstreamer1.0-plugins-base\
-                    libgstreamer-gl1.0-0\
-                    gstreamer1.0-plugins-bad\
-                    libopenjp2-7\
-                    libwebpdemux2\
-                    libenchant1c2a\
-                    libhyphen0\
-                    libgles2\
-                    gstreamer1.0-libav
+                               libopus0\
+                               libwoff1\
+                               libharfbuzz-icu0\
+                               gstreamer1.0-plugins-base\
+                               libgstreamer-gl1.0-0\
+                               gstreamer1.0-plugins-bad\
+                               libopenjp2-7\
+                               libwebpdemux2\
+                               libenchant1c2a\
+                               libhyphen0\
+                               libgles2\
+                               gstreamer1.0-libav
 
       - name: generate (pre-)release draft
         if: ${{ steps.prep.outputs.tag_name == '' }}
@@ -145,18 +145,18 @@ jobs:
           # Dependencies to launch webkit to inspect its version
           sudo apt-get update
           sudo apt-get install libegl1\
-                    libopus0\
-                    libwoff1\
-                    libharfbuzz-icu0\
-                    gstreamer1.0-plugins-base\
-                    libgstreamer-gl1.0-0\
-                    gstreamer1.0-plugins-bad\
-                    libopenjp2-7\
-                    libwebpdemux2\
-                    libenchant1c2a\
-                    libhyphen0\
-                    libgles2\
-                    gstreamer1.0-libav
+                               libopus0\
+                               libwoff1\
+                               libharfbuzz-icu0\
+                               gstreamer1.0-plugins-base\
+                               libgstreamer-gl1.0-0\
+                               gstreamer1.0-plugins-bad\
+                               libopenjp2-7\
+                               libwebpdemux2\
+                               libenchant1c2a\
+                               libhyphen0\
+                               libgles2\
+                               gstreamer1.0-libav
 
       - name: Get Playwright browser versions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,24 @@ jobs:
 
       - name: Install dependencies
         if: ${{ steps.prep.outputs.tag_name == '' }}
-        run: npm ci
+        run: |
+          npm ci
+
+          # Dependencies to launch webkit to inspect its version
+          sudo apt-get update
+          sudo apt-get install libegl1\
+                    libopus0\
+                    libwoff1\
+                    libharfbuzz-icu0\
+                    gstreamer1.0-plugins-base\
+                    libgstreamer-gl1.0-0\
+                    gstreamer1.0-plugins-bad\
+                    libopenjp2-7\
+                    libwebpdemux2\
+                    libenchant1c2a\
+                    libhyphen0\
+                    libgles2\
+                    gstreamer1.0-libav
 
       - name: generate (pre-)release draft
         if: ${{ steps.prep.outputs.tag_name == '' }}
@@ -121,7 +138,25 @@ jobs:
           node-version: 14.x
 
       - name: Install dependencies
-        run: npm ci
+        if: ${{ steps.prep.outputs.tag_name == '' }}
+        run: |
+          npm ci
+
+          # Dependencies to launch webkit to inspect its version
+          sudo apt-get update
+          sudo apt-get install libegl1\
+                    libopus0\
+                    libwoff1\
+                    libharfbuzz-icu0\
+                    gstreamer1.0-plugins-base\
+                    libgstreamer-gl1.0-0\
+                    gstreamer1.0-plugins-bad\
+                    libopenjp2-7\
+                    libwebpdemux2\
+                    libenchant1c2a\
+                    libhyphen0\
+                    libgles2\
+                    gstreamer1.0-libav
 
       - name: Get Playwright browser versions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,6 @@ jobs:
           node-version: 14.x
 
       - name: Install dependencies
-        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: |
           npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,13 +116,11 @@ jobs:
           echo "playwright_version=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
 
       - name: Setup Node version
-        if: ${{ steps.prep.outputs.tag_name == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
       - name: Install dependencies
-        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: npm ci
 
       - name: Get Playwright browser versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,22 +9,6 @@ jobs:
   build_and_test_docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libegl1\
-                    libopus0\
-                    libwoff1\
-                    libharfbuzz-icu0\
-                    gstreamer1.0-plugins-base\
-                    libgstreamer-gl1.0-0\
-                    gstreamer1.0-plugins-bad\
-                    libopenjp2-7\
-                    libwebpdemux2\
-                    libenchant1c2a\
-                    libhyphen0\
-                    libgles2\
-                    gstreamer1.0-libav
 
       -
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,24 +14,6 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
 
-
-      - name: Setup Node version
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Get Playwright browser versions
-        run: |
-          CHROMIUM_VERSION=$(node ./scripts/print-browser-version.js 'chromium')
-          echo "chromium_version=$CHROMIUM_VERSION" >> $GITHUB_ENV
-          FIREFOX_VERSION=$(node ./scripts/print-browser-version.js 'firefox')
-          echo "firefox_version=$FIREFOX_VERSION" >> $GITHUB_ENV
-          WEBKIT_VERSION=$(node ./scripts/print-browser-version.js 'webkit')
-          echo "webkit_version=$WEBKIT_VERSION" >> $GITHUB_ENV
-
       - run: make docker
         name: Make Docker
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
   build_and_test_docker:
     runs-on: ubuntu-latest
     steps:
-
       -
         name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,30 +12,41 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install libgl1\
-                               libegl1\
-                               libnotify4\
-                               libvpx6\
-                               libopus0\
-                               libxslt1.1\
-                               libwoff1\
-                               libharfbuzz-icu0\
-                               gstreamer1.0-plugins-base\
-                               libgstreamer1.0-0\
-                               libgstreamer-gl1.0-0\
-                               gstreamer1.0-plugins-bad\
-                               libopenjp2-7\
-                               libwebpdemux2\
-                               libenchant1c2a\
-                               libsecret-1-0\
-                               libhyphen0\
-                               libwayland-server0\
-                               libgles2\
-                               gstreamer1.0-libav
+          sudo apt-get install libegl1\
+                    libopus0\
+                    libwoff1\
+                    libharfbuzz-icu0\
+                    gstreamer1.0-plugins-base\
+                    libgstreamer-gl1.0-0\
+                    gstreamer1.0-plugins-bad\
+                    libopenjp2-7\
+                    libwebpdemux2\
+                    libenchant1c2a\
+                    libhyphen0\
+                    libgles2\
+                    gstreamer1.0-libav
 
       -
         name: Checkout
         uses: actions/checkout@v2
+
+
+      - name: Setup Node version
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get Playwright browser versions
+        run: |
+          CHROMIUM_VERSION=$(node ./scripts/print-browser-version.js 'chromium')
+          echo "chromium_version=$CHROMIUM_VERSION" >> $GITHUB_ENV
+          FIREFOX_VERSION=$(node ./scripts/print-browser-version.js 'firefox')
+          echo "firefox_version=$FIREFOX_VERSION" >> $GITHUB_ENV
+          WEBKIT_VERSION=$(node ./scripts/print-browser-version.js 'webkit')
+          echo "webkit_version=$WEBKIT_VERSION" >> $GITHUB_ENV
 
       - run: make docker
         name: Make Docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,29 @@ jobs:
   build_and_test_docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Install packages
+        run: |
+          sudo apt-get install libgl1\
+                               libegl1\
+                               libnotify4\
+                               libvpx6\
+                               libopus0\
+                               libxslt1.1\
+                               libwoff1\
+                               libharfbuzz-icu0\
+                               gstreamer1.0-plugins-base\
+                               libgstreamer1.0-0\
+                               libgstreamer-gl1.0-0\
+                               gstreamer1.0-plugins-bad\
+                               libopenjp2-7\
+                               libwebpdemux2\
+                               libenchant1c2a\
+                               libsecret-1-0\
+                               libhyphen0\
+                               libwayland-server0\
+                               libgles2\
+                               gstreamer1.0-libav
+
       -
         name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: Install packages
         run: |
+          sudo apt-get update
           sudo apt-get install libgl1\
                                libegl1\
                                libnotify4\


### PR DESCRIPTION
print-browser-version.js uses the playwright api directly so in order to use the script, playwright and browser dependencies need to be installed in order to query for browser versions.