### PR TITLE
[DEVX-1176] Set browser proxy via env var

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,28 @@
-module.exports = {
+const process = require('process');
+const _ = require('lodash');
+
+let custom = {};
+try {
+  // Import the user's config if it exists
+  custom = require('./playwright.config.js');
+} catch {
+}
+
+const defaults = {
   use: {
-    video: 'on',
+    headed: process.env.SAUCE_VM ? true : false,
+    video: process.env.SAUCE_VM ? 'off' : 'on',
   },
+  reporter: [
+    ['line'],
+    ['junit', { outputFile: 'junit.xml' }],
+  ],
 };
+
+if ('HTTP_PROXY' in process.env && process.env.HTTP_PROXY !== '') {
+  defaults.use.proxy = {
+    server: process.env.HTTP_PROXY,
+  };
+}
+
+module.exports = _.defaultsDeep(defaults, custom);

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -14,7 +14,7 @@ const defaults = {
     video: process.env.SAUCE_VM ? 'off' : 'on',
   },
   reporter: [
-    ['line'],
+    ['list'],
     ['junit', { outputFile: 'junit.xml' }],
   ],
 };

--- a/src/playwright-runner.js
+++ b/src/playwright-runner.js
@@ -226,18 +226,13 @@ async function run (nodeBin, runCfgPath, suiteName) {
     throw new Error(`Could not find projectPath directory: '${projectPath}'`);
   }
 
-  const defaultArgs = {
-    headed: process.env.SAUCE_VM ? true : false,
-    output: path.join(cwd, '__assets__'),
-    reporter: 'junit,list',
-  };
+  const configFile = path.join(projectPath, 'custom.config.js');
 
-  if (!process.env.SAUCE_VM) {
-    // Copy our own playwright configuration to the project folder (to enable video recording),
-    // as we currently don't support having a user provided playwright configuration yet.
-    fs.copyFileSync(path.join(__dirname, '..', 'playwright.config.js'), path.join(projectPath, 'playwright.config.js'));
-    defaultArgs.config = path.join(projectPath, 'playwright.config.js');
-  }
+  fs.copyFileSync(path.join(__dirname, '..', 'playwright.config.js'), configFile);
+  const defaultArgs = {
+    output: path.join(cwd, '__assets__'),
+    config: configFile,
+  };
 
   const playwrightBin = path.join(__dirname, '..', 'node_modules', '@playwright', 'test', 'lib', 'cli', 'cli.js');
   const procArgs = [
@@ -270,7 +265,6 @@ async function run (nodeBin, runCfgPath, suiteName) {
   let env = {
     ...process.env,
     ...suite.env,
-    PLAYWRIGHT_JUNIT_OUTPUT_NAME: path.join(cwd, '__assets__', 'junit.xml')
   };
 
   // Install NPM dependencies
@@ -297,10 +291,6 @@ async function run (nodeBin, runCfgPath, suiteName) {
   }
 
   // Move to __assets__
-  const files = glob.sync(path.join(projectPath, 'test-results', '*')) || [];
-  for (const file of files) {
-    fsExtra.moveSync(file, path.join(cwd, '__assets__', path.basename(file)));
-  }
 
   generateJunitfile(cwd, suiteName, args.param.browser, args.platformName);
 

--- a/tests/unit/src/playwright-runner.spec.js
+++ b/tests/unit/src/playwright-runner.spec.js
@@ -71,18 +71,17 @@ describe('playwright-runner', function () {
       const [[nodeBin, procArgs, spawnArgs]] = spawnMock.mock.calls;
       procArgs[0] = path.basename(procArgs[0]);
       spawnArgs.cwd = path.basename(spawnArgs.cwd);
-      spawnArgs.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME = path.basename(spawnArgs.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME);
       expect(nodeBin).toMatch('/fake/path/to/node');
       expect(procArgs).toMatchObject([
         'cli.js',
         'test',
-        '--headed',
         '--output',
         '/fake/runner/__assets__',
-        '--reporter',
-        'junit,list',
+        '--config',
+        '/fake/runner/custom.config.js',
         '--browser',
         'chromium',
+        '--headed',
         '**/*.spec.js',
         '**/*.test.js',
       ]);
@@ -90,7 +89,6 @@ describe('playwright-runner', function () {
         'cwd': 'runner',
         'env': {
           'HELLO': 'world',
-          'PLAYWRIGHT_JUNIT_OUTPUT_NAME': 'junit.xml',
           'SAUCE_TAGS': 'tag-one,tag-two',
         },
         'stdio': 'inherit',


### PR DESCRIPTION
Browser proxy can be set via playwright config, but only via the config file not via command line args.

We currently have a static config file that we use in docker mode to enable video (another option that is not exposed in cli args) and other configuration that is set through the command line args. Instead, use the config file for both docker mode and sauce mode and consolidate as much configuration there as possible.

I've also added support for a user's own config file. If there is a `playwright.config.js` file present, it'll be merged with our config file (with our values serving as defaults). There may be some unintended consequences so more exploration may be warranted. But I've included those changes here as a demonstration.