### PR TITLE
Support ts config

### DIFF
--- a/src/sauce.config.js
+++ b/src/sauce.config.js
@@ -1,10 +1,14 @@
 const process = require('process');
+const { accessSync, constants } = require('fs');
 const _ = require('lodash');
 
 let userConfig = {};
-try {
+if (accessSync('./playwright.config.js', constants.F_OK)) {
   userConfig = require('./playwright.config.js');
-} catch {}
+} else if (accessSync('./playwright.config.ts', constants.F_OK)) {
+  userConfig = require('./playwright.config.ts');
+}
+
 
 const overrides = {
   use: {

--- a/src/sauce.config.js
+++ b/src/sauce.config.js
@@ -3,14 +3,16 @@ const { accessSync, constants } = require('fs');
 const _ = require('lodash');
 
 let userConfig = {};
-try {
-  accessSync('./playwright.config.js', constants.F_OK);
-  userConfig = require('./playwright.config.js');
-} catch {}
-try {
-  accessSync('./playwright.config.ts', constants.F_OK);
-  userConfig = require('./playwright.config.ts');
-} catch {}
+
+// Prefer ts over js to match default behaviour of playwright-test
+const defaultConfigFiles = ['./playwright.config.ts', './playwright.config.js'];
+for (const file of defaultConfigFiles) {
+  try {
+    accessSync(file, constants.F_OK);
+    userConfig = require(file);
+    break;
+  } catch {}
+}
 
 const overrides = {
   use: {

--- a/src/sauce.config.js
+++ b/src/sauce.config.js
@@ -3,12 +3,14 @@ const { accessSync, constants } = require('fs');
 const _ = require('lodash');
 
 let userConfig = {};
-if (accessSync('./playwright.config.js', constants.F_OK)) {
+try {
+  accessSync('./playwright.config.js', constants.F_OK);
   userConfig = require('./playwright.config.js');
-} else if (accessSync('./playwright.config.ts', constants.F_OK)) {
+} catch {}
+try {
+  accessSync('./playwright.config.ts', constants.F_OK);
   userConfig = require('./playwright.config.ts');
-}
-
+} catch {}
 
 const overrides = {
   use: {

--- a/src/sauce.config.js
+++ b/src/sauce.config.js
@@ -1,5 +1,4 @@
 const process = require('process');
-const { accessSync, constants } = require('fs');
 const _ = require('lodash');
 
 let userConfig = {};
@@ -8,7 +7,6 @@ let userConfig = {};
 const defaultConfigFiles = ['./playwright.config.ts', './playwright.config.js'];
 for (const file of defaultConfigFiles) {
   try {
-    accessSync(file, constants.F_OK);
     userConfig = require(file);
     break;
   } catch {}


### PR DESCRIPTION
Playwright config can also be a typescript file. Load it if it exists, fallback to js, if not. This preference for the ts config matches the default behaviour of playwright-test.