### PR TITLE
[DEVX-1282] Run update-ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb
 
+# Remove DST Root as it has expired
+# https://bugs.launchpad.net/ubuntu/+source/ca-certificates/+bug/1944481
+RUN sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g' /etc/ca-certificates.conf
+RUN update-ca-certificates
+
+
 USER seluser
 
 #=================


### PR DESCRIPTION
Run `update-ca-certificates` + invalidate `DST Root X3` when building the docker image.