### PR TITLE
Node 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ steps.prep.outputs.tag_name == '' }}
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Setup Git
         if: ${{ steps.prep.outputs.tag_name == '' }}
@@ -120,7 +120,7 @@ jobs:
       - name: Setup Node version
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: |
@@ -202,11 +202,11 @@ jobs:
         with:
           ref: ${{ steps.prep.outputs.version }}
 
-      - name: Use Node.js v12.x
+      - name: Setup node version
         if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Update Release version
         if: ${{ steps.prep.outputs.asset_id == '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,10 +68,10 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Use Node.js v16.x
+      - name: Setup nodejs
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
@@ -119,10 +119,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Use Node.js v14.x
+      - name: Setup nodejs
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Install saucectl
         run: npm install -g saucectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ USER seluser
 #=================
 # Install Node.JS
 #=================
-ENV NODE_VERSION=14.18.1
+ENV NODE_VERSION=16.13.0
 ENV NVM_VERSION=0.39.0
 RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash \
   && export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@wdio/logger": "^5.16.10",
         "glob": "^7.1.6",
         "lodash": "^4.17.21",
+        "playwright": "1.15.2",
         "sauce-testrunner-utils": "0.5.0",
         "saucelabs": "^7.0.4",
         "shelljs": "^0.8.3",
@@ -35,7 +36,6 @@
         "jest-circus": "^26.4.2",
         "jest-cli": "^26.4.2",
         "mocha": "^8.1.3",
-        "playwright": "1.15.2",
         "release-it": "^14.4.1",
         "saucectl": "0.65.0",
         "typescript": "^3.9.7"
@@ -15903,7 +15903,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.15.2.tgz",
       "integrity": "sha512-+Z+7ckihyxR6rK5q8DWC6eUbKARfXpyxpjNcoJfgwSr64lAOzjhyFQiPC/JkdIqhsLgZjxpWfl1S7fLb+wPkgA==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "commander": "^6.1.0",
@@ -31157,7 +31156,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.15.2.tgz",
       "integrity": "sha512-+Z+7ckihyxR6rK5q8DWC6eUbKARfXpyxpjNcoJfgwSr64lAOzjhyFQiPC/JkdIqhsLgZjxpWfl1S7fLb+wPkgA==",
-      "dev": true,
       "requires": {
         "commander": "^6.1.0",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@wdio/logger": "^5.16.10",
     "glob": "^7.1.6",
     "lodash": "^4.17.21",
+    "playwright": "1.15.2",
     "sauce-testrunner-utils": "0.5.0",
     "saucelabs": "^7.0.4",
     "shelljs": "^0.8.3",
@@ -54,7 +55,6 @@
     "jest-circus": "^26.4.2",
     "jest-cli": "^26.4.2",
     "mocha": "^8.1.3",
-    "playwright": "1.15.2",
     "release-it": "^14.4.1",
     "saucectl": "0.65.0",
     "typescript": "^3.9.7"

--- a/src/playwright-runner.js
+++ b/src/playwright-runner.js
@@ -57,24 +57,49 @@ async function createJob (suiteName, hasPassed, startTime, endTime, args, playwr
   }
 
   let files = [
-    path.join(cwd, 'console.log'),
-    path.join(assetsDir, 'junit.xml'),
-    path.join(assetsDir, 'sauce-test-report.json'),
-    ...containerLogFiles
+    {
+      filename: 'console.log',
+      data: fs.readFileSync(path.join(cwd, 'console.log')),
+    },
+    {
+      filename: 'junit.xml',
+      data: fs.readFileSync(path.join(assetsDir, 'junit.xml')),
+    },
+    {
+      filename: 'sauce-test-report.json',
+      data: fs.readFileSync(path.join(assetsDir, 'sauce-test-report.json')),
+    },
   ];
+
+  for (const f of containerLogFiles) {
+    files.push(
+      {
+        filename: path.basename(f),
+        data: fs.readFileSync(f),
+      },
+    );
+  }
 
   // Upload metrics
   for (let [, mt] of Object.entries(metrics)) {
     if (_.isEmpty(mt.data)) {
       continue;
     }
-    let mtFile = path.join(assetsDir, mt.name);
-    fs.writeFileSync(mtFile, JSON.stringify(mt.data, ' ', 2));
-    files.push(mtFile);
+    files.push(
+      {
+        filename: mt.name,
+        data: mt.data,
+      },
+    );
   }
 
   if (videoLocation) {
-    files.push(videoLocation);
+    files.push(
+      {
+        filename: path.basename(videoLocation),
+        data: fs.readFileSync(videoLocation),
+      }
+    );
   }
 
   await Promise.all([

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -89,19 +89,14 @@ async function createJobReport (suiteName, metadata, api, passed, startTime, end
     saucectlVersion,
   };
 
-  let sessionId;
-  await api.createJob(
-        body
-  ).then(
-        (resp) => {
-          sessionId = resp.ID;
-        },
-        (e) => {
-          console.error('Create job failed: ', e.stack);
-        }
-  );
+  let resp;
+  try {
+    resp = await api.createJob(body);
+  } catch (e) {
+    console.error('Create job failed: ', e.stack);
+  }
 
-  return sessionId || 0;
+  return resp?.ID || 0;
 }
 
 module.exports.createJobReportV2 = createJobReportV2;


### PR DESCRIPTION
Bundle with node 16 (latest active release).

The upload issue with the saucelabs package seems related to a change in streams in node 16. The `got` package is used for http requests and there's a fix in got@12 that sounds like our issue: https://github.com/sindresorhus/got/commit/06a2d3d7d8d4fcc6898b6364d1a18ca1d407092b
So changed the way the upload files are passed to the upload function to avoid using streams. This is probably not desirable in the long term however.

The issue with the missing browsers was fixed by making `playwright` a prod dependency not just a dev dependency. The browsers weren't missing, but `npx playwright install` installed the wrong versions for some reason. No idea what is actually going on though which is a bummer.