### PR TITLE
[DEVX-1532] Keeps symlinks when building archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
 
       - name: Archive bundle
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        run: zip -r sauce-playwright-macos.zip bundle/
+        run: zip --symlinks -r sauce-playwright-macos.zip bundle/
 
       - name: Upload Release Asset
         if: ${{ steps.prep.outputs.asset_id == '' }}


### PR DESCRIPTION
When `zip` is running its default behaviour is to resolve symlinks instead of keeping then (as opposed to `tar`).
As WebKit on macOS relies on the system's one, symlinks to be respected when referring to an OS file.

Missing reference to system:
```
./WebKitLegacy.framework/Versions/A/WebKitPluginHost.app -> /System/Library/Frameworks/WebKit.framework/Versions/A/Frameworks/WebKitLegacy.framework/WebKitPluginHost.app
```

XPC (Apple IPC) that in consequence where not shared across processes:
```
./WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.GPU.xpc -> ../../../../com.apple.WebKit.GPU.xpc
./WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.Networking.xpc -> ../../../../com.apple.WebKit.Networking.xpc
./WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.WebContent.xpc -> ../../../../com.apple.WebKit.WebContent.xpc
```
