### PR TITLE
[DEVX-1637] Standardize release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,18 +229,28 @@ jobs:
         uses: azure/powershell@v1
         with:
           inlineScript: |
-            Compress-Archive bundle/ sauce-playwright-runner.zip
+            Compress-Archive bundle/ sauce-playwright-runner-win-amd64.zip
           azPSVersion: '3.1.0'
 
       - name: Upload Release Asset
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-playwright-runner-win-amd64.zip
+          asset_path: ./sauce-playwright-runner-win-amd64.zip
+          asset_name: sauce-playwright-runner-win-amd64.zip
+          asset_content_type: application/zip
+
+      - name: Upload Release Asset Legacy
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-playwright-runner.zip
-          asset_path: ./sauce-playwright-runner.zip
+          asset_path: ./sauce-playwright-runner-win-amd64.zip
           asset_name: sauce-playwright-runner.zip
           asset_content_type: application/zip
 
@@ -302,17 +312,27 @@ jobs:
 
       - name: Archive bundle
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        run: zip --symlinks -r sauce-playwright-macos.zip bundle/
+        run: zip --symlinks -r sauce-playwright-macos-amd64.zip bundle/
 
       - name: Upload Release Asset
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-playwright-macos-amd64.zip
+          asset_path: ./sauce-playwright-macos-amd64.zip
+          asset_name: sauce-playwright-macos-amd64.zip
+          asset_content_type: application/zip
+
+      - name: Upload Release Asset Legacy
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-playwright-macos.zip
-          asset_path: ./sauce-playwright-macos.zip
+          asset_path: ./sauce-playwright-macos-amd64.zip
           asset_name: sauce-playwright-macos.zip
           asset_content_type: application/zip
 

--- a/tests/fixtures/post-release/.sauce/config_win.yml
+++ b/tests/fixtures/post-release/.sauce/config_win.yml
@@ -10,7 +10,7 @@ rootDir: .
 playwright:
   # CAUTION: This has to be an already deployed framework version in the cloud. Not necessarily the one you want to test.
   # Then use --runner-version to specify the release you actually want to use.
-  version: 1.15.2
+  version: 1.18.1
 suites:
   - name: "Post Release Test (Windows) - chromium"
     platformName: "Windows 10"


### PR DESCRIPTION
Standardize release assets according to the new format: `{framework}-{os}-{arch}.zip`

This change does not replace legacy assets. At least not until all images are built using the new assets.
