### PR TITLE
[DEVX-1833] Fix merging array issue in playwright config

### DIFF
--- a/src/sauce.config.js
+++ b/src/sauce.config.js
@@ -57,4 +57,10 @@ if ('HTTP_PROXY' in process.env && process.env.HTTP_PROXY !== '') {
   overrides.use.launchOptions = { proxy, ignoreHTTPSErrors: true };
 }
 
-module.exports = _.merge(userConfig, overrides);
+function arrMerger (objValue, srcValue) {
+  if (_.isArray(objValue)) {
+    return objValue.concat(srcValue);
+  }
+}
+
+module.exports = _.mergeWith(userConfig, overrides, arrMerger);


### PR DESCRIPTION
`_.merge()` doesn't merge arrays. Add a function to merge them.

job example: https://app.saucelabs.com/tests/606eb02a95ba4e0ea33db501f9baa407