### PR TITLE
Allow users to add a single reporter without wrapping it in an array

### DIFF
--- a/src/sauce.config.js
+++ b/src/sauce.config.js
@@ -50,7 +50,7 @@ const overrides = {
 // Values that are arrays are merged at the very end (see arrMerger()), but primitives are not.
 // Allow the user to set a single reporter like so: `reporter: 'list'`.
 if (userConfig.reporter && !(userConfig.reporter instanceof Array)) {
-  overrides.reporter.push(userConfig.reporter);
+  overrides.reporter.push([userConfig.reporter]);
 }
 
 if (process.env.BROWSER_NAME !== 'chrome') {
@@ -69,12 +69,12 @@ if ('HTTP_PROXY' in process.env && process.env.HTTP_PROXY !== '') {
     server: process.env.HTTP_PROXY,
   };
 
-  overrides.use.contextOptions = { proxy, ignoreHTTPSErrors: true };
+  overrides.use.contextOptions = {proxy, ignoreHTTPSErrors: true};
   // Need to set the browser launch option as well, it is a hard requirement when testing chromium + windows.
-  overrides.use.launchOptions = { proxy, ignoreHTTPSErrors: true };
+  overrides.use.launchOptions = {proxy, ignoreHTTPSErrors: true};
 }
 
-function arrMerger (objValue, srcValue) {
+function arrMerger(objValue, srcValue) {
   if (_.isArray(objValue)) {
     return objValue.concat(srcValue);
   }

--- a/src/sauce.config.js
+++ b/src/sauce.config.js
@@ -47,6 +47,12 @@ const overrides = {
   testIgnore: process.env.TEST_IGNORE,
 };
 
+// Values that are arrays are merged at the very end (see arrMerger()), but primitives are not.
+// Allow the user to set a single reporter like so: `reporter: 'list'`.
+if (userConfig.reporter && !(userConfig.reporter instanceof Array)) {
+  overrides.reporter.push(userConfig.reporter);
+}
+
 if (process.env.BROWSER_NAME !== 'chrome') {
   // chromium, firefox and webkit come pre-packaged with playwright.
   // So we can just pass those browser values to playwright and


### PR DESCRIPTION
Allow users to specify a single reporter without wrapping it in an array.

Fixes https://github.com/saucelabs/saucectl-run-action/issues/20.

Example with my custom reporter: https://app.saucelabs.com/tests/7d8507ad35a1458ca990d1384a183fbb

And my playwright configuration:
```javascript
const config: PlaywrightTestConfig = {
  // ...
  reporter: './fancy.reporter.ts',
  // ..
};
```