### PR TITLE
[DEVX-2055] Fix -c usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,7 +274,10 @@ jobs:
 
       - name: Local Tests
         working-directory: tests/fixtures/cucumber/
-        run: npm i; node ../../../ --suiteName "cucumber local test" --runCfgPath ./sauce-runner.json
+        run: |
+          npm i
+          node ../../../ --suiteName "cucumber local test" --runCfgPath ./sauce-runner.json
+          node ../../../ --suiteName "cucumber config test" --runCfgPath ./sauce-runner.json
         env:
           SAUCE_VM: true
 

--- a/src/cucumber-runner.js
+++ b/src/cucumber-runner.js
@@ -18,7 +18,8 @@ function buildArgs (runCfg, cucumberBin) {
   ];
   if (runCfg.suite.options.config) {
     procArgs.push('-c');
-    procArgs.push(path.join(runCfg.projectPath, runCfg.suite.options.config));
+    // NOTE: cucumber-js constructs the absolute path automatically and expects a relative path here
+    procArgs.push(runCfg.suite.options.config);
   }
   if (runCfg.suite.options.name) {
     procArgs.push('--name');

--- a/tests/fixtures/cucumber/cucumber-saucectl.mjs
+++ b/tests/fixtures/cucumber/cucumber-saucectl.mjs
@@ -1,0 +1,3 @@
+export default {
+  require: ['features/support/*.js'],
+};

--- a/tests/fixtures/cucumber/sauce-runner.json
+++ b/tests/fixtures/cucumber/sauce-runner.json
@@ -20,6 +20,17 @@
          "paths": ["features/**/*.feature"],
          "require": ["features/support/*.js"]
       }
+    },
+    {
+      "name": "cucumber config test",
+      "browserName": "chromium",
+      "browserVersion": "101",
+      "options": {
+        "config": "./cucumber-saucectl.mjs",
+        "paths": [
+          "features/**/*.feature"
+        ]
+      }
     }
   ],
   "npm": {


### PR DESCRIPTION
cucumber-js expects a relative path for the `-c` flag. If an absolute path is provided, `-c /a/b/c/file`, you get something like `-c /a/b/c/a/b/c/file`