### PR TITLE
Let cucumber force exit when meeting failure

### DIFF
--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -14,6 +14,7 @@ function buildArgs (runCfg: CucumberRunnerConfig, cucumberBin: string) {
     cucumberBin,
     ...paths,
     '--publish-quiet',
+    '--force-exit',
     '--require-module', 'ts-node/register',
     '--format', '@saucelabs/cucumber-reporter',
     '--format-options', JSON.stringify(buildFormatOption(runCfg)),


### PR DESCRIPTION
When there is a step failed, cucumber keeps the browser open instead of closing it. Let it force exit.