### PR TITLE
Simplify Node selection in Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,7 @@ on:
         default: ''
 
 jobs:
-  vars:
-    runs-on: ubuntu-latest
-    outputs:
-      nodeVersion: ${{ steps.nodeVersion.outputs.nodeVersion }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - id: nodeVersion
-        run: echo "nodeVersion=`cat .nvmrc | tr -d 'v'`" >> "$GITHUB_OUTPUT"
-
   create-release-draft:
-    needs: [vars]
     runs-on: ubuntu-latest
     steps:
       - name: Check Tag
@@ -57,7 +44,7 @@ jobs:
         if: ${{ steps.prep.outputs.tag_name == '' }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Setup Git
@@ -91,7 +78,7 @@ jobs:
 
   release-windows-bundle:
     runs-on: windows-latest
-    needs: [vars, create-release-draft]
+    needs: [create-release-draft]
     steps:
       - name: Find Matching Draft Tag
         id: prep
@@ -143,7 +130,7 @@ jobs:
         if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Update Release Version
@@ -176,7 +163,7 @@ jobs:
 
   release-macos-bundle:
     runs-on: macos-latest
-    needs: [vars, create-release-draft]
+    needs: [create-release-draft]
     steps:
       - name: Find Matching Draft Tag
         id: prep
@@ -214,7 +201,7 @@ jobs:
         if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Update Release Version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,20 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  vars:
-    runs-on: ubuntu-latest
-    outputs:
-      nodeVersion: ${{ steps.nodeVersion.outputs.nodeVersion }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - id: nodeVersion
-        run: echo "nodeVersion=`cat .nvmrc | tr -d 'v'`" >> "$GITHUB_OUTPUT"
-
   test:
-    needs: [vars]
     runs-on: ubuntu-latest
 
     steps:
@@ -37,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies
@@ -51,7 +38,6 @@ jobs:
 
   build-and-test-local:
     runs-on: windows-latest
-    needs: [vars]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install Dependencies
@@ -76,7 +62,6 @@ jobs:
 
   cucumber-build-and-test-local:
     runs-on: windows-latest
-    needs: [vars]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -84,7 +69,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies
@@ -106,7 +91,7 @@ jobs:
 
   build-windows-bundle:
     runs-on: windows-latest
-    needs: [vars, test]
+    needs: [test]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -114,7 +99,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Setup Python
@@ -153,7 +138,7 @@ jobs:
 
   build-macos-bundle:
     runs-on: macos-latest
-    needs: [vars, test]
+    needs: [test]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -161,7 +146,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Set up Python
@@ -288,7 +273,7 @@ jobs:
             --select-suite "${{ matrix.os }} - ${{ matrix.browser }}"
 
   cucumber-bundle-test:
-    needs: [vars, build-windows-bundle, build-macos-bundle]
+    needs: [build-windows-bundle, build-macos-bundle]
     strategy:
       fail-fast: false
       matrix:
@@ -301,7 +286,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ needs.vars.outputs.nodeVersion }}
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Setup saucectl


### PR DESCRIPTION
Rely on `node-version-file` from `actions/setup-node@v3` instead of manually do the thing.