### PR TITLE
Update parsing of playwright version from package-lock

### DIFF
--- a/.github/helpers/generate-release-notes.sh
+++ b/.github/helpers/generate-release-notes.sh
@@ -4,8 +4,8 @@
 CHANGELOG=$(git --no-pager log --no-notes --no-decorate --oneline  v${1}...HEAD)
 
 ## Gather Framework version
-PLAYWRIGHT_VER=$(< package-lock.json jq -r '.dependencies["playwright"].version')
-PLAYWRIGHT_TEST_VER=$(< package-lock.json jq -r '.dependencies["@playwright/test"].version')
+PLAYWRIGHT_VER=$(< package-lock.json jq -r '.packages[""].dependencies["playwright"]')
+PLAYWRIGHT_TEST_VER=$(< package-lock.json jq -r '.packages[""].dependencies["@playwright/test"]')
 NODEJS_VER=$(cat .nvmrc | tr -d "v")
 
 ## Add Browser versions


### PR DESCRIPTION
The "dependencies" object is actually obsolete, but remains for backwards compability. Read the framework version from the "packages" object.