### PR TITLE
fix: Don't clobber launchOptions when setting proxy

### DIFF
--- a/src/sauce.config.cjs
+++ b/src/sauce.config.cjs
@@ -72,7 +72,11 @@ if ('HTTP_PROXY' in process.env && process.env.HTTP_PROXY !== '') {
 
   overrides.use.contextOptions = {proxy, ignoreHTTPSErrors: true};
   // Need to set the browser launch option as well, it is a hard requirement when testing chromium + windows.
-  overrides.use.launchOptions = {proxy, ignoreHTTPSErrors: true};
+  overrides.use.launchOptions = {
+    ...overrides.use.launchOptions,
+    proxy,
+    ignoreHTTPSErrors: true,
+  };
 }
 
 function arrMerger(objValue, srcValue) {

--- a/src/sauce.config.cjs
+++ b/src/sauce.config.cjs
@@ -31,6 +31,7 @@ const overrides = {
     headless: process.env.HEADLESS === 'true',
     video: 'off',
     launchOptions: {},
+    contextOptions: {},
   },
   reporter: [
     ['list'],
@@ -70,7 +71,11 @@ if ('HTTP_PROXY' in process.env && process.env.HTTP_PROXY !== '') {
     server: process.env.HTTP_PROXY,
   };
 
-  overrides.use.contextOptions = {proxy, ignoreHTTPSErrors: true};
+  overrides.use.contextOptions = {
+    ...overrides.use.contextOptions,
+    proxy,
+    ignoreHTTPSErrors: true,
+  };
   // Need to set the browser launch option as well, it is a hard requirement when testing chromium + windows.
   overrides.use.launchOptions = {
     ...overrides.use.launchOptions,


### PR DESCRIPTION
Setting chrome and a proxy both need to add configuration to the `config.use.launchOptions` object. Don't clobber previous launchOptions when setting the proxy.

Working example: https://app.saucelabs.com/tests/12078a3400a3495a8dcb49295182dc63

DEVX-2481