### PR TITLE
fix: Set global timeout conditionally

### DIFF
--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -227,10 +227,6 @@ async function runPlaywright(nodeBin: string, runCfg: RunnerConfig): Promise<Run
     playwrightBin, 'test'
   ];
 
-  // Default value for timeout (30min)
-  if (!suite.param.globalTimeout) {
-    suite.param.timeout = 1800000;
-  }
   let args: Record<string, unknown> = _.defaultsDeep(defaultArgs, utils.replaceLegacyKeys(suite.param));
 
   // There is a conflict if the playwright project has a `browser` defined,

--- a/src/sauce.config.cjs
+++ b/src/sauce.config.cjs
@@ -26,6 +26,12 @@ for (const file of configFiles) {
   }
 }
 
+// Set a default timeout of 30 minutes if one is not provided. This protects
+// against tests that hang and never finish.
+if (!userConfig.globalTimeout) {
+  userConfig.globalTimeout = 1000 * 60 * 30; // 30 minutes
+}
+
 const overrides = {
   use: {
     headless: process.env.HEADLESS === 'true',

--- a/src/sauce.config.mjs
+++ b/src/sauce.config.mjs
@@ -27,6 +27,12 @@ for (const file of configFiles) {
   }
 }
 
+// Set a default timeout of 30 minutes if one is not provided. This protects
+// against tests that hang and never finish.
+if (!userConfig.globalTimeout) {
+  userConfig.globalTimeout = 1000 * 60 * 30; // 30 minutes
+}
+
 const overrides = {
   use: {
     headless: process.env.HEADLESS === 'true',


### PR DESCRIPTION
Set the global timeout conditionally, that is, the user didn't set one in their native playwright config file. This allows the user retain their existing timeout configuration and still be able to override it if necessary via saucectl.

This fix addresses the following issues:
- The **default** timeout for the entire execution was incorrectly set as the test level timeout
- The **default** acted as a constant override, rather than default, causing customer provided values inside the native playwright config to be overridden at all times
- The user had to set both the `globalTimeout` **and** the regular `timeout`, so that `timeout` wasn't overridden by the default