### PR TITLE
feat: add default global timeout

### DIFF
--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -2,7 +2,7 @@ import {spawn} from 'node:child_process';
 import * as path from 'node:path';
 import {prepareNpmEnv, preExec} from 'sauce-testrunner-utils';
 
-import type {CucumberRunnerConfig, Metrics, RunResult} from './types';
+import type {CucumberRunnerConfig, RunResult} from './types';
 import * as utils from './utils';
 
 function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
@@ -78,9 +78,7 @@ export async function runCucumber(nodeBin: string, runCfg: CucumberRunnerConfig)
   const nodeCtx = {nodePath: nodeBin, npmPath: npmBin};
 
   // Install NPM dependencies
-  const metrics: Metrics[] = [];
-  const npmMetrics = await prepareNpmEnv(runCfg, nodeCtx);
-  metrics.push(npmMetrics);
+  await prepareNpmEnv(runCfg, nodeCtx);
 
   const startTime = new Date().toISOString();
   // Run suite preExecs
@@ -89,7 +87,6 @@ export async function runCucumber(nodeBin: string, runCfg: CucumberRunnerConfig)
       startTime,
       endTime: new Date().toISOString(),
       hasPassed: false,
-      metrics,
     };
   }
 
@@ -119,7 +116,6 @@ export async function runCucumber(nodeBin: string, runCfg: CucumberRunnerConfig)
     startTime,
     endTime,
     hasPassed: passed,
-    metrics,
   };
 }
 

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -80,12 +80,9 @@ export async function runCucumber(nodeBin: string, runCfg: CucumberRunnerConfig)
   // Install NPM dependencies
   await prepareNpmEnv(runCfg, nodeCtx);
 
-  const startTime = new Date().toISOString();
   // Run suite preExecs
   if (!await preExec.run(runCfg.suite, runCfg.preExecTimeout)) {
     return {
-      startTime,
-      endTime: new Date().toISOString(),
       hasPassed: false,
     };
   }
@@ -110,11 +107,8 @@ export async function runCucumber(nodeBin: string, runCfg: CucumberRunnerConfig)
   } catch (e) {
     console.error(`Could not complete job. Reason: ${e}`);
   }
-  const endTime = new Date().toISOString();
 
   return {
-    startTime,
-    endTime,
     hasPassed: passed,
   };
 }

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -10,7 +10,6 @@ import * as convert from 'xml-js';
 import {runCucumber} from './cucumber-runner';
 import type {
   CucumberRunnerConfig,
-  Metrics,
   RunnerConfig,
   RunResult,
 } from './types';
@@ -272,16 +271,12 @@ async function runPlaywright(nodeBin: string, runCfg: RunnerConfig): Promise<Run
 
   utils.setEnvironmentVariables(env);
 
-  // Install NPM dependencies
-  const metrics: Metrics[] = [];
-
   // Define node/npm path for execution
   const npmBin = path.join(path.dirname(nodeBin), 'node_modules', 'npm', 'bin', 'npm-cli.js');
   const nodeCtx = { nodePath: nodeBin, npmPath: npmBin };
 
   // runCfg.path must be set for prepareNpmEnv to find node_modules. :(
-  const npmMetrics = await prepareNpmEnv(runCfg, nodeCtx);
-  metrics.push(npmMetrics);
+  await prepareNpmEnv(runCfg, nodeCtx);
 
   const startTime = new Date().toISOString();
   // Run suite preExecs
@@ -290,7 +285,6 @@ async function runPlaywright(nodeBin: string, runCfg: RunnerConfig): Promise<Run
       startTime,
       endTime: new Date().toISOString(),
       hasPassed: false,
-      metrics,
     };
   }
 
@@ -318,7 +312,6 @@ async function runPlaywright(nodeBin: string, runCfg: RunnerConfig): Promise<Run
     startTime,
     endTime,
     hasPassed,
-    metrics,
   };
 }
 

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -278,12 +278,9 @@ async function runPlaywright(nodeBin: string, runCfg: RunnerConfig): Promise<Run
   // runCfg.path must be set for prepareNpmEnv to find node_modules. :(
   await prepareNpmEnv(runCfg, nodeCtx);
 
-  const startTime = new Date().toISOString();
   // Run suite preExecs
   if (!await preExec.run(suite, runCfg.preExecTimeout)) {
     return {
-      startTime,
-      endTime: new Date().toISOString(),
       hasPassed: false,
     };
   }
@@ -306,11 +303,8 @@ async function runPlaywright(nodeBin: string, runCfg: RunnerConfig): Promise<Run
   } catch (e) {
     console.error(`Could not complete job. Reason: ${e}`);
   }
-  const endTime = new Date().toISOString()
 
   return {
-    startTime,
-    endTime,
     hasPassed,
   };
 }

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -23,7 +23,7 @@ function getPlatformName(platformName: string) {
   return platformName;
 }
 
-function generateJunitfile(sourceFile: string, suiteName: string, browserName: string, platformName: string) {
+function generateJunitFile(sourceFile: string, suiteName: string, browserName: string, platformName: string) {
   if (!fs.existsSync(sourceFile)) {
     return;
   }
@@ -173,7 +173,7 @@ async function run(nodeBin: string, runCfgPath: string, suiteName: string) {
   } else {
     result = await runPlaywright(nodeBin, runCfg);
     try {
-      generateJunitfile(runCfg.junitFile, runCfg.suite.name, runCfg.suite.param.browser, runCfg.suite.platformName);
+      generateJunitFile(runCfg.junitFile, runCfg.suite.name, runCfg.suite.param.browser, runCfg.suite.platformName);
     } catch (err) {
       console.error(`Failed to generate junit file: ${err}`);
     }

--- a/src/sauce.config.cjs
+++ b/src/sauce.config.cjs
@@ -26,12 +26,6 @@ for (const file of configFiles) {
   }
 }
 
-// Set a default timeout of 30 minutes if one is not provided. This protects
-// against tests that hang and never finish.
-if (!userConfig.globalTimeout) {
-  userConfig.globalTimeout = 1000 * 60 * 30; // 30 minutes
-}
-
 const overrides = {
   use: {
     headless: process.env.HEADLESS === 'true',

--- a/src/sauce.config.mjs
+++ b/src/sauce.config.mjs
@@ -27,12 +27,6 @@ for (const file of configFiles) {
   }
 }
 
-// Set a default timeout of 30 minutes if one is not provided. This protects
-// against tests that hang and never finish.
-if (!userConfig.globalTimeout) {
-  userConfig.globalTimeout = 1000 * 60 * 30; // 30 minutes
-}
-
 const overrides = {
   use: {
     headless: process.env.HEADLESS === 'true',

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,7 @@ import type { Region } from '@saucelabs/testcomposer';
 export type Browser = 'chromium' | 'firefox' | 'webkit' | 'chrome';
 
 export interface RunResult {
-  startTime: string;
   hasPassed: boolean;
-  endTime: string;
 }
 
 export interface RunnerConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface Suite {
   env?: Record<string, string>;
   preExec: string[];
   testIgnore?: string[];
+  timeout?: number;
 }
 
 export interface SuiteConfig {
@@ -102,4 +103,5 @@ export interface CucumberSuite {
     parallel?: number;
     paths: string[];
   };
+  timeout?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,5 @@
 import type { Region } from '@saucelabs/testcomposer';
 
-export type Browser = 'chromium' | 'firefox' | 'webkit' | 'chrome';
-
 export interface RunnerConfig {
   // NOTE: Kind is serialized by saucectl with a capital 'K' ¯\_(ツ)_/¯
   Kind: 'playwright';

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,20 +2,10 @@ import type { Region } from '@saucelabs/testcomposer';
 
 export type Browser = 'chromium' | 'firefox' | 'webkit' | 'chrome';
 
-export interface Metrics {
-  name: string;
-  data: {
-    install: {duration: number};
-    rebuild?: {duration: number};
-    setup: {duration: number};
-  };
-}
-
 export interface RunResult {
   startTime: string;
   hasPassed: boolean;
   endTime: string;
-  metrics: Metrics[];
 }
 
 export interface RunnerConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,10 +2,6 @@ import type { Region } from '@saucelabs/testcomposer';
 
 export type Browser = 'chromium' | 'firefox' | 'webkit' | 'chrome';
 
-export interface RunResult {
-  hasPassed: boolean;
-}
-
 export interface RunnerConfig {
   // NOTE: Kind is serialized by saucectl with a capital 'K' ¯\_(ツ)_/¯
   Kind: 'playwright';

--- a/tests/fixtures/local/basic-js/sauce-runner.json
+++ b/tests/fixtures/local/basic-js/sauce-runner.json
@@ -21,7 +21,6 @@
               "repeatEach": 1,
               "retries": 0,
               "shard": "1/2",
-              "timeout": 30000,
               "maxFailures": 2
             },
             "testMatch": ".*.js"


### PR DESCRIPTION
Add a global default timeout. The default setting of playwright's native global timeout was removed in favor of the process based timeout, which is more consistent with our other runner implementations. It's still configurable by the user though.