### PR TITLE
fix: apply overrides correctly when using mjs config with a tunnel

### DIFF
--- a/src/sauce.config.mjs
+++ b/src/sauce.config.mjs
@@ -71,9 +71,17 @@ if ('HTTP_PROXY' in process.env && process.env.HTTP_PROXY !== '') {
     server: process.env.HTTP_PROXY,
   };
 
-  overrides.use.contextOptions = { proxy, ignoreHTTPSErrors: true };
+  overrides.use.contextOptions = {
+    ...overrides.use.contextOptions,
+    proxy,
+    ignoreHTTPSErrors: true,
+  };
   // Need to set the browser launch option as well, it is a hard requirement when testing chromium + windows.
-  overrides.use.launchOptions = { proxy, ignoreHTTPSErrors: true };
+  overrides.use.launchOptions = {
+    ...overrides.use.launchOptions,
+    proxy,
+    ignoreHTTPSErrors: true,
+  };
 }
 
 function arrMerger(objValue, srcValue) {


### PR DESCRIPTION
This simply re-aligns the mjs and cjs config files.