### PR TITLE
feat: Sync attachments to assets directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@playwright/test": "1.41.2",
-        "@saucelabs/playwright-reporter": "1.0.0",
+        "@saucelabs/playwright-reporter": "1.1.0",
         "@saucelabs/testcomposer": "2.0.0",
         "dotenv": "16.4.5",
         "lodash": "4.17.21",
@@ -2970,12 +2970,12 @@
       }
     },
     "node_modules/@saucelabs/playwright-reporter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@saucelabs/playwright-reporter/-/playwright-reporter-1.0.0.tgz",
-      "integrity": "sha512-eTsWftBE0hD0jlQabwV6ktxavNB66G9VUCIl4//z6kkDdxABPEvtuP6WcM4CZDxOps7GyGVJOZQhSHhDIi8otw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@saucelabs/playwright-reporter/-/playwright-reporter-1.1.0.tgz",
+      "integrity": "sha512-OLvVsVxRVRqdwX4Fvuwnx/rdhWQvnXSRhKBmh0sWYPe0qG4A4BCjdMREEzWz6/DDDKwhOt50ryTqhbbU5tdJKg==",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "3.0.3",
-        "@saucelabs/testcomposer": "^1.2.1",
+        "@saucelabs/testcomposer": "2.0.1",
         "axios": "1.5.1",
         "debug": "^4.3.4"
       },
@@ -2987,12 +2987,15 @@
       }
     },
     "node_modules/@saucelabs/playwright-reporter/node_modules/@saucelabs/testcomposer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-1.2.1.tgz",
-      "integrity": "sha512-kYyx2vul32SOJa6iSZK6mKj69r+y73SOO05KcjvWUQ62n4KlKAJChPHPdzWR0Lh4/uGBhDdVyy9f8aC6UTZW9w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-2.0.1.tgz",
+      "integrity": "sha512-AJdnneRZbZujTVgDE8nmPBzf64hEC1kpzGWFU2cAxDJFk/XIGNNZkU8becY4tBEpzDMF57ePvAOW9Bfe++kPdA==",
       "dependencies": {
-        "axios": "^1.0.0",
+        "axios": "^1.5.1",
         "form-data": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.13.2"
       }
     },
     "node_modules/@saucelabs/sauce-json-reporter": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/saucelabs/sauce-playwright-runner",
   "dependencies": {
     "@playwright/test": "1.41.2",
-    "@saucelabs/playwright-reporter": "1.0.0",
+    "@saucelabs/playwright-reporter": "1.1.0",
     "@saucelabs/testcomposer": "2.0.0",
     "dotenv": "16.4.5",
     "lodash": "4.17.21",

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -275,7 +275,7 @@ async function runPlaywright(
 
   const defaultArgs = {
     output:
-      runCfg.env?.SAUCE_SYNC_WEB_ASSETS === 'true'
+      suite.env?.SAUCE_SYNC_WEB_ASSETS === 'true'
         ? undefined
         : runCfg.playwrightOutputFolder,
     config: configFile,
@@ -336,7 +336,7 @@ async function runPlaywright(
     SAUCE_REPORT_OUTPUT_NAME: runCfg.sauceReportFile,
     FORCE_COLOR: '0',
     SAUCE_WEB_ASSETS_DIR:
-      runCfg.env?.SAUCE_SYNC_WEB_ASSETS === 'true' ? runCfg.assetsDir : '',
+      suite.env?.SAUCE_SYNC_WEB_ASSETS === 'true' ? runCfg.assetsDir : '',
   };
 
   utils.setEnvironmentVariables(env);

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -313,8 +313,8 @@ async function runPlaywright(
     key = utils.toHyphenated(key);
     if (
       excludeParams.includes(key.toLowerCase()) ||
-      value === undefined ||
-      value === null
+      value === false ||
+      value == null
     ) {
       continue;
     }

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -341,7 +341,9 @@ async function runPlaywright(
     SAUCE_REPORT_OUTPUT_NAME: runCfg.sauceReportFile,
     FORCE_COLOR: '0',
     SAUCE_WEB_ASSETS_DIR:
-      suite.env?.SAUCE_SYNC_WEB_ASSETS === 'true' ? runCfg.assetsDir : '',
+      suite.env?.SAUCE_SYNC_WEB_ASSETS.toLowerCase() === 'true'
+        ? runCfg.assetsDir
+        : '',
   };
 
   utils.setEnvironmentVariables(env);

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -277,7 +277,7 @@ async function runPlaywright(
     output:
       suite.env?.SAUCE_SYNC_WEB_ASSETS !== 'true'
         ? runCfg.playwrightOutputFolder
-        : undefined,
+        : null,
     config: configFile,
   };
 

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -274,12 +274,13 @@ async function runPlaywright(
   fs.copyFileSync(path.join(__dirname, configFileName), configFile);
 
   const defaultArgs = {
-    output:
-      suite.env?.SAUCE_SYNC_WEB_ASSETS !== 'true'
-        ? runCfg.playwrightOutputFolder
-        : null,
     config: configFile,
   };
+
+  if (suite.env?.SAUCE_SYNC_WEB_ASSETS !== 'true') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (defaultArgs as any).output = runCfg.playwrightOutputFolder;
+  }
 
   const playwrightBin = path.join(
     __dirname,

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -301,8 +301,6 @@ async function runPlaywright(
     utils.replaceLegacyKeys(suite.param),
   );
 
-  console.log('args: ', args);
-
   // There is a conflict if the playwright project has a `browser` defined,
   // since the job is launched with the browser set by saucectl, which is now set as the job's metadata.
   const isRunProject = Object.keys(args).find((k) => k === 'project');
@@ -313,7 +311,11 @@ async function runPlaywright(
   // eslint-disable-next-line prefer-const
   for (let [key, value] of Object.entries(args)) {
     key = utils.toHyphenated(key);
-    if (excludeParams.includes(key.toLowerCase()) || value === false) {
+    if (
+      excludeParams.includes(key.toLowerCase()) ||
+      value === undefined ||
+      value === null
+    ) {
       continue;
     }
     procArgs.push(`--${key}`);

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -274,9 +274,10 @@ async function runPlaywright(
   fs.copyFileSync(path.join(__dirname, configFileName), configFile);
 
   const defaultArgs = {
-    output: process.env.SAUCE_ENABLE_SYNC_ASSETS
-      ? undefined
-      : runCfg.playwrightOutputFolder,
+    output:
+      process.env.SAUCE_ENABLE_SYNC_ASSETS === 'true'
+        ? undefined
+        : runCfg.playwrightOutputFolder,
     config: configFile,
   };
 

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -175,7 +175,15 @@ async function getCfg(
     runCfg.sauce = {};
   }
   runCfg.sauce.region = runCfg.sauce.region || 'us-west-1';
-  runCfg.playwrightOutputFolder = path.join(runCfg.assetsDir, 'test-results');
+  runCfg.playwrightOutputFolder =
+    suite.env?.SAUCE_SYNC_WEB_ASSETS?.toLowerCase() === 'true'
+      ? ''
+      : path.join(runCfg.assetsDir, 'test-results');
+
+  runCfg.webAssetsDir =
+    suite.env?.SAUCE_SYNC_WEB_ASSETS?.toLowerCase() === 'true'
+      ? runCfg.assetsDir
+      : '';
 
   return runCfg;
 }
@@ -274,17 +282,9 @@ async function runPlaywright(
   fs.copyFileSync(path.join(__dirname, configFileName), configFile);
 
   const defaultArgs = {
+    output: runCfg.playwrightOutputFolder,
     config: configFile,
   };
-
-  // Set the Playwright output folder if SAUCE_SYNC_WEB_ASSETS is not enabled.
-  if (
-    !suite.env?.SAUCE_SYNC_WEB_ASSETS ||
-    suite.env.SAUCE_SYNC_WEB_ASSETS.toLowerCase() !== 'true'
-  ) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (defaultArgs as any).output = runCfg.playwrightOutputFolder;
-  }
 
   const playwrightBin = path.join(
     __dirname,

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -340,10 +340,7 @@ async function runPlaywright(
     PLAYWRIGHT_JUNIT_OUTPUT_NAME: runCfg.junitFile,
     SAUCE_REPORT_OUTPUT_NAME: runCfg.sauceReportFile,
     FORCE_COLOR: '0',
-    SAUCE_WEB_ASSETS_DIR:
-      suite.env?.SAUCE_SYNC_WEB_ASSETS.toLowerCase() === 'true'
-        ? runCfg.assetsDir
-        : '',
+    SAUCE_WEB_ASSETS_DIR: runCfg.webAssetsDir,
   };
 
   utils.setEnvironmentVariables(env);

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -274,7 +274,9 @@ async function runPlaywright(
   fs.copyFileSync(path.join(__dirname, configFileName), configFile);
 
   const defaultArgs = {
-    output: runCfg.playwrightOutputFolder,
+    output: process.env.SAUCE_ENABLE_SYNC_ASSETS
+      ? undefined
+      : runCfg.playwrightOutputFolder,
     config: configFile,
   };
 
@@ -332,6 +334,8 @@ async function runPlaywright(
     PLAYWRIGHT_JUNIT_OUTPUT_NAME: runCfg.junitFile,
     SAUCE_REPORT_OUTPUT_NAME: runCfg.sauceReportFile,
     FORCE_COLOR: '0',
+    SAUCE_SYNC_ASSETS_DIR:
+      process.env.SAUCE_ENABLE_SYNC_ASSETS === 'true' ? runCfg.assetsDir : '',
   };
 
   utils.setEnvironmentVariables(env);

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -275,7 +275,7 @@ async function runPlaywright(
 
   const defaultArgs = {
     output:
-      process.env.SAUCE_SYNC_WEB_ASSETS === 'true'
+      runCfg.env?.SAUCE_SYNC_WEB_ASSETS === 'true'
         ? undefined
         : runCfg.playwrightOutputFolder,
     config: configFile,
@@ -336,7 +336,7 @@ async function runPlaywright(
     SAUCE_REPORT_OUTPUT_NAME: runCfg.sauceReportFile,
     FORCE_COLOR: '0',
     SAUCE_WEB_ASSETS_DIR:
-      process.env.SAUCE_SYNC_WEB_ASSETS === 'true' ? runCfg.assetsDir : '',
+      runCfg.env?.SAUCE_SYNC_WEB_ASSETS === 'true' ? runCfg.assetsDir : '',
   };
 
   utils.setEnvironmentVariables(env);

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -177,7 +177,7 @@ async function getCfg(
   runCfg.sauce.region = runCfg.sauce.region || 'us-west-1';
   runCfg.playwrightOutputFolder =
     suite.env?.SAUCE_SYNC_WEB_ASSETS?.toLowerCase() === 'true'
-      ? ''
+      ? undefined
       : path.join(runCfg.assetsDir, 'test-results');
 
   runCfg.webAssetsDir =
@@ -300,6 +300,8 @@ async function runPlaywright(
     defaultArgs,
     utils.replaceLegacyKeys(suite.param),
   );
+
+  console.log('args: ', args);
 
   // There is a conflict if the playwright project has a `browser` defined,
   // since the job is launched with the browser set by saucectl, which is now set as the job's metadata.

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -277,7 +277,11 @@ async function runPlaywright(
     config: configFile,
   };
 
-  if (suite.env?.SAUCE_SYNC_WEB_ASSETS !== 'true') {
+  // Set the Playwright output folder if SAUCE_SYNC_WEB_ASSETS is not enabled.
+  if (
+    !suite.env?.SAUCE_SYNC_WEB_ASSETS ||
+    suite.env.SAUCE_SYNC_WEB_ASSETS.toLowerCase() !== 'true'
+  ) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (defaultArgs as any).output = runCfg.playwrightOutputFolder;
   }

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -275,9 +275,9 @@ async function runPlaywright(
 
   const defaultArgs = {
     output:
-      suite.env?.SAUCE_SYNC_WEB_ASSETS === 'true'
-        ? undefined
-        : runCfg.playwrightOutputFolder,
+      suite.env?.SAUCE_SYNC_WEB_ASSETS !== 'true'
+        ? runCfg.playwrightOutputFolder
+        : undefined,
     config: configFile,
   };
 

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -314,7 +314,8 @@ async function runPlaywright(
     if (
       excludeParams.includes(key.toLowerCase()) ||
       value === false ||
-      value == null
+      value === undefined ||
+      value === null
     ) {
       continue;
     }

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -275,7 +275,7 @@ async function runPlaywright(
 
   const defaultArgs = {
     output:
-      process.env.SAUCE_ENABLE_SYNC_ASSETS === 'true'
+      process.env.SAUCE_SYNC_WEB_ASSETS === 'true'
         ? undefined
         : runCfg.playwrightOutputFolder,
     config: configFile,
@@ -335,8 +335,8 @@ async function runPlaywright(
     PLAYWRIGHT_JUNIT_OUTPUT_NAME: runCfg.junitFile,
     SAUCE_REPORT_OUTPUT_NAME: runCfg.sauceReportFile,
     FORCE_COLOR: '0',
-    SAUCE_SYNC_ASSETS_DIR:
-      process.env.SAUCE_ENABLE_SYNC_ASSETS === 'true' ? runCfg.assetsDir : '',
+    SAUCE_WEB_ASSETS_DIR:
+      process.env.SAUCE_SYNC_WEB_ASSETS === 'true' ? runCfg.assetsDir : '',
   };
 
   utils.setEnvironmentVariables(env);

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,9 +27,9 @@ export interface RunnerConfig {
   preExecTimeout: number;
   path: string;
   projectPath: string;
-  playwrightOutputFolder: string;
+  playwrightOutputFolder?: string;
   // webAssetsDir contains assets compatible with the Sauce Labs web UI.
-  webAssetsDir: string;
+  webAssetsDir?: string;
   suite: Suite;
 
   args: Record<string, unknown>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface RunnerConfig {
 
   args: Record<string, unknown>;
   artifacts: Artifacts;
+  env?: Record<string, string>;
 }
 
 export interface Suite {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,8 @@ export interface RunnerConfig {
   path: string;
   projectPath: string;
   playwrightOutputFolder: string;
+  // webAssetsDir contains assets compatible with the Sauce Labs web UI.
+  webAssetsDir?: string;
   suite: Suite;
 
   args: Record<string, unknown>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,6 @@ export interface RunnerConfig {
 
   args: Record<string, unknown>;
   artifacts: Artifacts;
-  env?: Record<string, string>;
 }
 
 export interface Suite {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface RunnerConfig {
   projectPath: string;
   playwrightOutputFolder: string;
   // webAssetsDir contains assets compatible with the Sauce Labs web UI.
-  webAssetsDir?: string;
+  webAssetsDir: string;
   suite: Suite;
 
   args: Record<string, unknown>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,9 @@ export function replaceLegacyKeys(config: SuiteConfig) {
   return args;
 }
 
-export function setEnvironmentVariables(envVars: Record<string, string> = {}) {
+export function setEnvironmentVariables(
+  envVars: Record<string, string | undefined> = {},
+) {
   if (!envVars) {
     return;
   }


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Control the sync assets feature using the `SAUCE_SYNC_WEB_ASSETS` global environment variable:
- Resets the Playwright output directory.
- Configures the sync asset directory for the Playwright reporter.

Feel free to suggest other env var name to replace `SAUCE_SYNC_WEB_ASSETS`.

Job example: https://app.saucelabs.com/tests/b7e69e6cc94f4616bec8c5f05b7a3824