### PR TITLE
deps: Bump sauce-testrunner-utils to support more npm auth fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dotenv": "16.4.5",
         "lodash": "4.17.21",
         "playwright": "1.43.1",
-        "sauce-testrunner-utils": "2.1.1",
+        "sauce-testrunner-utils": "2.2.0",
         "xml-js": "1.6.11"
       },
       "devDependencies": {
@@ -13846,9 +13846,9 @@
       "dev": true
     },
     "node_modules/sauce-testrunner-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-2.1.1.tgz",
-      "integrity": "sha512-2ZME0GUv4sUWTW8Ome61aqupVvF5LH5ue08ml+2XGD8lawE4R2+pjySnErvtyRQPEXsrVgQEq6czNdIVNg/FpQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-2.2.0.tgz",
+      "integrity": "sha512-Xj30zT+5Kfs4Y6PhDqqkwrKKynkuOkDddemy09wmBnfEdwryawWhJpEKJmr7nsV+ya9tgKf/KIebT1x1S4cz7A==",
       "dependencies": {
         "lodash": "^4.17.21",
         "npm": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dotenv": "16.4.5",
     "lodash": "4.17.21",
     "playwright": "1.43.1",
-    "sauce-testrunner-utils": "2.1.1",
+    "sauce-testrunner-utils": "2.2.0",
     "xml-js": "1.6.11"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Support npm fields:
- `auth`
- `username`
- `password`
- `email`