### PR TITLE
build: downgrade to Node.js 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,6 +187,9 @@ jobs:
       matrix:
         os: [Win10, Win11, macOS12, macOS13]
         browser: [Chromium, Firefox, Webkit]
+        exclude:
+          - os: macOS12
+            browser: Webkit
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -225,6 +228,8 @@ jobs:
           - os: Win10
             browser: Webkit
           - os: Win11
+            browser: Webkit
+          - os: macOS12
             browser: Webkit
       fail-fast: false
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,11 +8,6 @@ module.exports = ts.config(
   ...ts.configs.recommended,
   prettier,
   {
-    plugins: {
-      jest: jest,
-    },
-  },
-  {
     ignores: ['lib/**'],
   },
   {
@@ -23,6 +18,10 @@ module.exports = ts.config(
       'no-control-regex': 'off',
       'no-undef': 'warn',
     },
+  },
+  {
+    files: ['tests/**/*.*js', 'tests/**/*.*ts'],
+    ...jest.configs['flat/recommended'],
   },
   {
     languageOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,7 @@ module.exports = ts.config(
         exports: true,
         module: true,
         require: true,
+        process: true,
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@babel/core": "^7.24.7",
         "@babel/preset-env": "^7.24.7",
-        "@tsconfig/node22": "^22.0.0",
+        "@tsconfig/node20": "^20.1.4",
         "@types/jest": "^29.5.12",
         "@types/lodash": "^4.17.4",
         "@types/node": "^20.14.2",
@@ -3107,10 +3107,10 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true
     },
-    "node_modules/@tsconfig/node22": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.0.tgz",
-      "integrity": "sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==",
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
+      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
       "dev": true
     },
     "node_modules/@types/babel__core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@babel/core": "^7.24.7",
         "@babel/preset-env": "^7.24.7",
+        "@eslint/js": "^9.4.0",
         "@tsconfig/node20": "^20.1.4",
         "@types/jest": "^29.5.12",
         "@types/lodash": "^4.17.4",
@@ -1907,12 +1908,12 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
+      "integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
       "dev": true,
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5392,6 +5393,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
+    "@eslint/js": "^9.4.0",
     "@tsconfig/node20": "^20.1.4",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
-    "@tsconfig/node22": "^22.0.0",
+    "@tsconfig/node20": "^20.1.4",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.4",
     "@types/node": "^20.14.2",

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import * as path from 'node:path';
+import { setTimeout } from 'node:timers';
 import { prepareNpmEnv, preExec } from 'sauce-testrunner-utils';
 
 import type { CucumberRunnerConfig } from './types';

--- a/src/playwright-runner.ts
+++ b/src/playwright-runner.ts
@@ -2,6 +2,7 @@
 import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { setTimeout } from 'node:timers';
 
 import _ from 'lodash';
 import {

--- a/tests/fixtures/cloud/cucumber/features/support/steps.js
+++ b/tests/fixtures/cloud/cucumber/features/support/steps.js
@@ -2,6 +2,7 @@ const { Before, When, Then } = require('@cucumber/cucumber');
 const { chromium, firefox, webkit } = require('playwright');
 const { expect } = require('@playwright/test');
 const prettySeconds = require('pretty-seconds');
+const { setTimeout } = require('node:timers');
 
 Before(async function () {
   const opts = {

--- a/tests/fixtures/local/cucumber/features/support/steps.js
+++ b/tests/fixtures/local/cucumber/features/support/steps.js
@@ -1,5 +1,6 @@
 const { Before, When, Then } = require('@cucumber/cucumber');
 const { chromium, firefox, webkit } = require('playwright');
+const { setTimeout } = require('node:timers');
 
 Before(async function () {
   const opts = {

--- a/tests/fixtures/post-release/cucumber/features/support/steps.js
+++ b/tests/fixtures/post-release/cucumber/features/support/steps.js
@@ -2,6 +2,7 @@ const { Before, When, Then } = require('@cucumber/cucumber');
 const { chromium, firefox, webkit } = require('playwright');
 const { expect } = require('@playwright/test');
 const prettySeconds = require('pretty-seconds');
+const { setTimeout } = require('node:timers');
 
 Before(async function () {
   const opts = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {


### PR DESCRIPTION
## Description

Downgrade to Node.js 20. It wasn't actually properly on Node.js 22, because `.nvmrc` was still on `v20`—and remains as such.

Additional changes:
- Eslint was misconfigured, with the `jest` configuration not taking effect. Fixed and optimized it for tests only.