### PR TITLE
ci: unpin saucectl version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Parse Release Version
         id: parse_version
@@ -319,7 +318,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Parse Release Version
         id: parse_version
@@ -353,7 +351,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Parse Release Version
         id: parse_version
@@ -388,7 +385,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Parse Release Version
         id: parse_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,7 +203,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Test on Sauce
         working-directory: ./tests/fixtures/cloud
@@ -250,7 +249,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Run web-page
         run: |
@@ -302,7 +300,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           skip-run: true
-          saucectl-version: v0.184.1
 
       - name: Test on Sauce
         working-directory: ./tests/fixtures/cloud/cucumber


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

With the fix https://github.com/saucelabs/saucectl/pull/955, we can unpin saucectl version.