### PR TITLE
feat!: update cucumber format parsing

### DIFF
--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -19,7 +19,7 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
     '--require-module',
     'ts-node/register',
     '--format',
-    '@saucelabs/cucumber-reporter',
+    '"@saucelabs/cucumber-reporter":"sauce-test-report.json"',
     '--format-options',
     JSON.stringify(buildFormatOption(runCfg)),
   ];

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -75,8 +75,11 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
  * Normalizes a Cucumber-js format string.
  *
  * For structured inputs (`key:value` or `"key:value"`), returns a string in the
- * form `"key":"value"`, with the asset directory prepended to relative paths.
- * For simple inputs (e.g., `usage`), returns the input as-is.
+ * form `"key":"value"`. If the value starts with `file://`, it is treated as an
+ * absolute path and no asset directory is prepended. Otherwise, the asset
+ * directory is prepended to relative paths.
+ *
+ * For simple inputs (e.g., `usage`), the input is returned unchanged.
  *
  * @param {string} format - The input format string. Examples include:
  *                          - `"key:value"`
@@ -84,13 +87,13 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
  *                          - `key:value`
  *                          - `usage`
  * @param {string} assetDir - The directory to prepend to the value for relative paths.
- * @returns {string} The normalized format string. For structured inputs, it returns
- *                   a string in the form `"key":"value"`. For simple inputs, it
- *                   returns the input unchanged.
+ * @returns {string} The normalized format string.
  *
  * Example:
  * - Input: `"html":"formatter/report.html"`, `"/project/assets"`
  *   Output: `"html":"/project/assets/formatter/report.html"`
+ * - Input: `"html":"file://formatter/report.html"`, `"/project/assets"`
+ *   Output: `"html":"file://formatter/report.html"`
  * - Input: `"usage"`, `"/project/assets"`
  *   Output: `"usage"`
  */

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -104,8 +104,10 @@ export function normalizeFormat(format: string, assetDir: string): string {
   let [, key, value] = match;
   key = key.replaceAll('"', '');
   value = value.replaceAll('"', '');
-  const updatedPath = path.join(assetDir, value);
-  return `"${key}":"${updatedPath}"`;
+  if (value.startsWith('file://')) {
+    return `"${key}":"${value}"`;
+  }
+  return `"${key}":"${path.join(assetDir, value)}"`;
 }
 
 export async function runCucumber(

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -204,5 +204,6 @@ function buildFormatOption(cfg: CucumberRunnerConfig) {
     build: cfg.sauce.metadata?.build,
     tags: cfg.sauce.metadata?.tags,
     outputFile: path.join(cfg.assetsDir, 'sauce-test-report.json'),
+    ...cfg.suite.options.formatOptions,
   };
 }

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -122,10 +122,6 @@ export function normalizeFormat(format: string, assetDir: string): string {
   key = key.replaceAll('"', '');
   value = value.replaceAll('"', '');
 
-  if (value.startsWith('file://')) {
-    return `"${key}":"${value}"`;
-  }
-
   return `"${key}":"${path.join(assetDir, value)}"`;
 }
 

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -74,12 +74,10 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
 /**
  * Normalizes a Cucumber-js format string.
  *
- * For structured inputs (`key:value`, `"key:value"`, or `"key":"value"`), returns a string
- * in the form `"key":"value"`. If the value starts with `file://`, it is treated as an
- * absolute path, and no asset directory is prepended. Otherwise, the asset directory
- * is prepended to relative paths.
- *
- * For simple inputs (e.g., `usage`) or other unstructured formats, the input is returned unchanged.
+ * This function handles structured inputs in the format `key:value`, `"key:value"`,
+ * or `"key":"value"` and returns a normalized string in the form `"key":"value"`.
+ * For simple inputs (e.g., `usage`) or unstructured formats, the function returns the
+ * input unchanged.
  *
  * @param {string} format - The input format string. Examples include:
  *                          - `"key:value"`
@@ -93,19 +91,16 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
  * Examples:
  * - Input: `"html:formatter/report.html"`, `"/project/assets"`
  *   Output: `"html":"/project/assets/formatter/report.html"`
- * - Input: `"html":"file://formatter/report.html"`, `"/project/assets"`
- *   Output: `"html":"file://formatter/report.html"`
  * - Input: `"usage"`, `"/project/assets"`
  *   Output: `"usage"`
  * - Input: `"file://implementation":"output_file"`, `"/project/assets"`
- *   Output: `"file://implementation":"/project/assets/output_file"`
+ *   Output: `"file://implementation":"output_file"` (unchanged)
  */
 export function normalizeFormat(format: string, assetDir: string): string {
   // Try to match structured inputs in the format key:value, "key:value", or "key":"value".
   let match = format.match(/^"?([^:]+):"?([^"]+)"?$/);
 
   if (!match) {
-    // Check if the format uses a file path starting with "file://".
     if (!format.startsWith('"file://')) {
       return format;
     }

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -18,6 +18,11 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
     '--force-exit',
     '--require-module',
     'ts-node/register',
+    // NOTE: Cucumber only supports a single stdout formatter. If multiple stdout
+    // formatters are specified, Cucumber will use the last one provided.
+    // To ensure the sauce test report file is always generated, redirect the output to
+    // sauce-test-report.json using the --format argument and specify the outputFile
+    // in --format-options simultaneously.
     '--format',
     '"@saucelabs/cucumber-reporter":"sauce-test-report.json"',
     '--format-options',

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -18,7 +18,7 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
     '--force-exit',
     '--require-module',
     'ts-node/register',
-    // NOTE: The Cucumber formatter (--format) setting uses the "type:path" format.
+    // NOTE: The Cucumber formatter (--format) setting uses the "type":"path" format.
     // If the "path" is not provided, the output defaults to stdout.
     // Cucumber supports only one stdout formatter; if multiple are specified,
     // it will prioritize the last one listed.

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -84,6 +84,8 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
  * For simple inputs (e.g., `usage`) or unstructured formats, the function returns the
  * input unchanged.
  *
+ * If the input starts with `file://`, an error is thrown to indicate an invalid format.
+ *
  * @param {string} format - The input format string. Examples include:
  *                          - `"key:value"`
  *                          - `"key":"value"`
@@ -102,6 +104,13 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
  *   Output: `"file://implementation":"output_file"` (unchanged)
  */
 export function normalizeFormat(format: string, assetDir: string): string {
+  // Formats starting with file:// are not supported by the current implementation.
+  // Restrict users from using this format.
+  if (format.startsWith('file://')) {
+    throw new Error(
+      `Invalid format setting detected. The provided format "${format}" is not allowed.`,
+    );
+  }
   // Try to match structured inputs in the format key:value, "key:value", or "key":"value".
   let match = format.match(/^"?([^:]+):"?([^"]+)"?$/);
 

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -51,9 +51,8 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
   });
 
   runCfg.suite.options.format?.forEach((format) => {
-    const updatedFormat = normalizeFormat(format, runCfg.assetsDir);
     procArgs.push('--format');
-    procArgs.push(updatedFormat);
+    procArgs.push(normalizeFormat(format, runCfg.assetsDir));
   });
 
   if (runCfg.suite.options.parallel) {
@@ -61,7 +60,6 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
     procArgs.push(runCfg.suite.options.parallel.toString(10));
   }
 
-  console.log('procArgs: ', procArgs);
   return procArgs;
 }
 
@@ -89,6 +87,7 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
  *   Output: `"progress-bar"`
  */
 export function normalizeFormat(format: string, assetDir: string): string {
+  // Checks if the format is structured; if not, returns it unchanged.
   const match = format.match(/^"?([^:]+):"?([^"]+)"?$/);
   if (!match) {
     return format;

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -18,11 +18,14 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
     '--force-exit',
     '--require-module',
     'ts-node/register',
-    // NOTE: Cucumber only supports a single stdout formatter. If multiple stdout
-    // formatters are specified, Cucumber will use the last one provided.
-    // To ensure the sauce test report file is always generated, redirect the output to
-    // sauce-test-report.json using the --format argument and specify the outputFile
-    // in --format-options simultaneously.
+    // NOTE: The Cucumber formatter (--format) setting follows the "type":"path" format.
+    // If the "path" is missing, the output defaults to stdout.
+    // Cucumber supports only one stdout formatter, and if multiple are specified,
+    // it will use the last one provided.
+    // To ensure the Sauce test report file is always generated,
+    // set the output to a file using the --format option,
+    // and use the --format-options flag to specify the outputFile.
+    // Both fields must be configured for the file to be created reliably.
     '--format',
     '"@saucelabs/cucumber-reporter":"sauce-test-report.json"',
     '--format-options',

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -18,14 +18,14 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
     '--force-exit',
     '--require-module',
     'ts-node/register',
-    // NOTE: The Cucumber formatter (--format) setting follows the "type":"path" format.
-    // If the "path" is missing, the output defaults to stdout.
-    // Cucumber supports only one stdout formatter, and if multiple are specified,
-    // it will use the last one provided.
-    // To ensure the Sauce test report file is always generated,
-    // set the output to a file using the --format option,
-    // and use the --format-options flag to specify the outputFile.
-    // Both fields must be configured for the file to be created reliably.
+    // NOTE: The Cucumber formatter (--format) setting uses the "type:path" format.
+    // If the "path" is not provided, the output defaults to stdout.
+    // Cucumber supports only one stdout formatter; if multiple are specified,
+    // it will prioritize the last one listed.
+    // To ensure the Sauce test report file is always generated and not overridden
+    // by a user-specified stdout formatter, set the output to a file using the --format option
+    // and configure the --format-options flag to specify the outputFile.
+    // Both settings must be properly configured to reliably generate the file.
     '--format',
     '"@saucelabs/cucumber-reporter":"sauce-test-report.json"',
     '--format-options',

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -18,16 +18,21 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
     '--force-exit',
     '--require-module',
     'ts-node/register',
-    // NOTE: The Cucumber formatter (--format) setting uses the "type":"path" format.
-    // If the "path" is not provided, the output defaults to stdout.
+    // NOTE: The Cucumber formatter (--format) option uses the "type":"path" format.
+    // If the "path" is not specified, the output defaults to stdout.
     // Cucumber supports only one stdout formatter; if multiple are specified,
-    // it will prioritize the last one listed.
-    // To ensure the Sauce test report file is always generated and not overridden
-    // by a user-specified stdout formatter, set the output to a file using the --format option
-    // and configure the --format-options flag to specify the outputFile.
-    // Both settings must be properly configured to reliably generate the file.
+    // the last one listed takes precedence.
+    //
+    // To ensure the Sauce test report file is reliably generated and not overridden
+    // by a user-specified stdout formatter, configure the following:
+    // 1. In the --format option, set the output to a file (e.g., cucumber.log) to
+    //    avoid writing to stdout.
+    // 2. Use the --format-options flag to explicitly specify the outputFile
+    //    (e.g., sauce-test-report.json).
+    //
+    // Both settings must be configured correctly to ensure the Sauce test report file is generated.
     '--format',
-    '"@saucelabs/cucumber-reporter":"sauce-test-report.json"',
+    '"@saucelabs/cucumber-reporter":"cucumber.log"',
     '--format-options',
     JSON.stringify(buildFormatOption(runCfg)),
   ];

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -66,25 +66,32 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
 }
 
 /**
- * Normalizes a Cucumber format string by ensuring it is in the form of `"key":"value"`.
+ * Normalizes a Cucumber-js format string.
  *
- * @param {string} format - The input format string, which can be in various forms:
+ * For structured inputs (`key:value` or `"key:value"`), returns a string in the
+ * form `"key":"value"`, with the asset directory prepended to relative paths.
+ * For simple inputs (e.g., `progress-bar`), returns the input as-is.
+ *
+ * @param {string} format - The input format string. Examples include:
  *                          - `"key:value"`
  *                          - `"key":"value"`
  *                          - `key:value`
- * @param {string} assetDir - The asset directory.
- * @throws {Error} If the input format is invalid (e.g., missing a colon separator).
- * @returns {string} The normalized format string in the form of `"key":"value"`,
- *                   with the asset directory prepended to relative paths.
+ *                          - `progress-bar`
+ * @param {string} assetDir - The directory to prepend to the value for relative paths.
+ * @returns {string} The normalized format string. For structured inputs, it returns
+ *                   a string in the form `"key":"value"`. For simple inputs, it
+ *                   returns the input unchanged.
  *
  * Example:
- * Input: `"html:formatter/report.html"`, `"/project/assets"`
- * Output: `"html":"/project/assets/formatter/report.html"`
+ * - Input: `"html":"formatter/report.html"`, `"/project/assets"`
+ *   Output: `"html":"/project/assets/formatter/report.html"`
+ * - Input: `"progress-bar"`, `"/project/assets"`
+ *   Output: `"progress-bar"`
  */
 export function normalizeFormat(format: string, assetDir: string): string {
   const match = format.match(/^"?([^:]+):"?([^"]+)"?$/);
   if (!match) {
-    throw new Error(`Invalid format: ${format}`);
+    return format;
   }
 
   let [, key, value] = match;

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -209,9 +209,6 @@ export async function runCucumber(
 function buildFormatOption(cfg: CucumberRunnerConfig) {
   return {
     upload: false,
-    suiteName: cfg.suite.name,
-    build: cfg.sauce.metadata?.build,
-    tags: cfg.sauce.metadata?.tags,
     outputFile: path.join(cfg.assetsDir, 'sauce-test-report.json'),
     ...cfg.suite.options.formatOptions,
   };

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -108,7 +108,7 @@ export function normalizeFormat(format: string, assetDir: string): string {
   // Restrict users from using this format.
   if (format.startsWith('file://')) {
     throw new Error(
-      `Invalid format setting detected. The provided format "${format}" is not allowed.`,
+      `Ambiguous colon usage detected. The provided format "${format}" is not allowed.`,
     );
   }
   // Try to match structured inputs in the format key:value, "key:value", or "key":"value".

--- a/src/cucumber-runner.ts
+++ b/src/cucumber-runner.ts
@@ -68,13 +68,13 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
  *
  * For structured inputs (`key:value` or `"key:value"`), returns a string in the
  * form `"key":"value"`, with the asset directory prepended to relative paths.
- * For simple inputs (e.g., `progress-bar`), returns the input as-is.
+ * For simple inputs (e.g., `usage`), returns the input as-is.
  *
  * @param {string} format - The input format string. Examples include:
  *                          - `"key:value"`
  *                          - `"key":"value"`
  *                          - `key:value`
- *                          - `progress-bar`
+ *                          - `usage`
  * @param {string} assetDir - The directory to prepend to the value for relative paths.
  * @returns {string} The normalized format string. For structured inputs, it returns
  *                   a string in the form `"key":"value"`. For simple inputs, it
@@ -83,8 +83,8 @@ export function buildArgs(runCfg: CucumberRunnerConfig, cucumberBin: string) {
  * Example:
  * - Input: `"html":"formatter/report.html"`, `"/project/assets"`
  *   Output: `"html":"/project/assets/formatter/report.html"`
- * - Input: `"progress-bar"`, `"/project/assets"`
- *   Output: `"progress-bar"`
+ * - Input: `"usage"`, `"/project/assets"`
+ *   Output: `"usage"`
  */
 export function normalizeFormat(format: string, assetDir: string): string {
   // Checks if the format is structured; if not, returns it unchanged.
@@ -94,8 +94,8 @@ export function normalizeFormat(format: string, assetDir: string): string {
   }
 
   let [, key, value] = match;
-  key = key.replace(/^"|"$/g, '');
-  value = value.replace(/^"|"$/g, '');
+  key = key.replaceAll('"', '');
+  value = value.replaceAll('"', '');
   const updatedPath = path.join(assetDir, value);
   return `"${key}":"${updatedPath}"`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,7 @@ export interface CucumberSuite {
     import?: string[];
     tags?: string[];
     format?: string[];
-    formatOptions?: object;
+    formatOptions?: { [key: string]: string };
     parallel?: number;
     paths: string[];
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,7 @@ export interface CucumberSuite {
     import?: string[];
     tags?: string[];
     format?: string[];
+    formatOptions?: object;
     parallel?: number;
     paths: string[];
   };

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -54,12 +54,8 @@ describe('normalizeFormat', () => {
     );
   });
 
-  it('should throw an error for invalid formats', () => {
-    expect(() =>
-      normalizeFormat(`html-formatter/report.html`, assetDir),
-    ).toThrow('Invalid format: html-formatter/report.html');
-    expect(() =>
-      normalizeFormat(`"htmlformatter/report.html"`, assetDir),
-    ).toThrow('Invalid format: "htmlformatter/report.html"');
+  it('should return simple strings as-is', () => {
+    expect(normalizeFormat(`"progress-bar"`, assetDir)).toBe('"progress-bar"');
+    expect(normalizeFormat(`progress-bar`, assetDir)).toBe('progress-bar');
   });
 });

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -54,18 +54,6 @@ describe('normalizeFormat', () => {
     );
   });
 
-  it('should normalize formats with absolute path', () => {
-    expect(
-      normalizeFormat(`"html":"file:///tmp/formatter/report.html"`, assetDir),
-    ).toBe(`"html":"file:///tmp/formatter/report.html"`);
-    expect(
-      normalizeFormat(`"html:file:///tmp/formatter/report.html"`, assetDir),
-    ).toBe(`"html":"file:///tmp/formatter/report.html"`);
-    expect(
-      normalizeFormat(`html:file:///tmp/formatter/report.html`, assetDir),
-    ).toBe(`"html":"file:///tmp/formatter/report.html"`);
-  });
-
   it('should normalize format with file path type', () => {
     expect(
       normalizeFormat(

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -26,7 +26,7 @@ describe('buildArgs', () => {
       '--require-module',
       'ts-node/register',
       '--format',
-      '@saucelabs/cucumber-reporter',
+      '"@saucelabs/cucumber-reporter":"sauce-test-report.json"',
       '--format-options',
       '{"upload":false,"outputFile":"/project/assets/sauce-test-report.json"}',
     ]);

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -55,7 +55,7 @@ describe('normalizeFormat', () => {
   });
 
   it('should return simple strings as-is', () => {
-    expect(normalizeFormat(`"progress-bar"`, assetDir)).toBe('"progress-bar"');
-    expect(normalizeFormat(`progress-bar`, assetDir)).toBe('progress-bar');
+    expect(normalizeFormat(`"usage"`, assetDir)).toBe('"usage"');
+    expect(normalizeFormat(`usage`, assetDir)).toBe('usage');
   });
 });

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -54,9 +54,15 @@ describe('normalizeFormat', () => {
     );
   });
 
-  it('should normalize format with absolute path', () => {
+  it('should normalize formats with absolute path', () => {
     expect(
       normalizeFormat(`"html":"file:///tmp/formatter/report.html"`, assetDir),
+    ).toBe(`"html":"file:///tmp/formatter/report.html"`);
+    expect(
+      normalizeFormat(`"html:file:///tmp/formatter/report.html"`, assetDir),
+    ).toBe(`"html":"file:///tmp/formatter/report.html"`);
+    expect(
+      normalizeFormat(`html:file:///tmp/formatter/report.html`, assetDir),
     ).toBe(`"html":"file:///tmp/formatter/report.html"`);
   });
 

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -1,0 +1,65 @@
+const { buildArgs, normalizeFormat } = require('../../../src/cucumber-runner');
+
+describe('buildArgs', () => {
+  const cucumberBin = '/usr/local/bin/cucumber';
+
+  it('should build correct arguments with basic configuration', () => {
+    const runCfg = {
+      sauce: {
+        metadata: {},
+      },
+      projectPath: '/project',
+      assetsDir: '/project/assets',
+      suite: {
+        options: {
+          paths: ['features/test.feature'],
+        },
+      },
+    };
+
+    const result = buildArgs(runCfg, cucumberBin);
+
+    expect(result).toEqual([
+      cucumberBin,
+      '/project/features/test.feature',
+      '--force-exit',
+      '--require-module',
+      'ts-node/register',
+      '--format',
+      '@saucelabs/cucumber-reporter',
+      '--format-options',
+      '{"upload":false,"outputFile":"/project/assets/sauce-test-report.json"}',
+    ]);
+  });
+});
+
+describe('normalizeFormat', () => {
+  const assetDir = '/project/assets';
+
+  it('should normalize formats with both quoted format type and path', () => {
+    expect(normalizeFormat(`"html":"formatter/report.html"`, assetDir)).toBe(
+      `"html":"/project/assets/formatter/report.html"`,
+    );
+  });
+
+  it('should normalize formats with only one pair of quote', () => {
+    expect(normalizeFormat(`"html:formatter/report.html"`, assetDir)).toBe(
+      `"html":"/project/assets/formatter/report.html"`,
+    );
+  });
+
+  it('should normalize formats with no quotes', () => {
+    expect(normalizeFormat(`html:formatter/report.html`, assetDir)).toBe(
+      `"html":"/project/assets/formatter/report.html"`,
+    );
+  });
+
+  it('should throw an error for invalid formats', () => {
+    expect(() =>
+      normalizeFormat(`html-formatter/report.html`, assetDir),
+    ).toThrow('Invalid format: html-formatter/report.html');
+    expect(() =>
+      normalizeFormat(`"htmlformatter/report.html"`, assetDir),
+    ).toThrow('Invalid format: "htmlformatter/report.html"');
+  });
+});

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -36,22 +36,28 @@ describe('buildArgs', () => {
 describe('normalizeFormat', () => {
   const assetDir = '/project/assets';
 
-  it('should normalize formats with both quoted format type and path', () => {
+  it('should normalize format with both quoted format type and path', () => {
     expect(normalizeFormat(`"html":"formatter/report.html"`, assetDir)).toBe(
       `"html":"/project/assets/formatter/report.html"`,
     );
   });
 
-  it('should normalize formats with only one pair of quote', () => {
+  it('should normalize format with only one pair of quote', () => {
     expect(normalizeFormat(`"html:formatter/report.html"`, assetDir)).toBe(
       `"html":"/project/assets/formatter/report.html"`,
     );
   });
 
-  it('should normalize formats with no quotes', () => {
+  it('should normalize format with no quotes', () => {
     expect(normalizeFormat(`html:formatter/report.html`, assetDir)).toBe(
       `"html":"/project/assets/formatter/report.html"`,
     );
+  });
+
+  it('should normalize format with absolute path', () => {
+    expect(
+      normalizeFormat(`"html":"file:///tmp/formatter/report.html"`, assetDir),
+    ).toBe(`"html":"file:///tmp/formatter/report.html"`);
   });
 
   it('should return simple strings as-is', () => {

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -14,7 +14,7 @@ describe('buildArgs', () => {
         options: {
           paths: ['features/test.feature'],
           formatOptions: {
-            build: 'mybuild',
+            myOption: 'test',
           },
         },
       },
@@ -31,7 +31,7 @@ describe('buildArgs', () => {
       '--format',
       '"@saucelabs/cucumber-reporter":"cucumber.log"',
       '--format-options',
-      '{"upload":false,"build":"mybuild","outputFile":"/project/assets/sauce-test-report.json"}',
+      '{"upload":false,"outputFile":"/project/assets/sauce-test-report.json","myOption":"test"}',
     ]);
   });
 });

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -29,7 +29,7 @@ describe('buildArgs', () => {
       '--require-module',
       'ts-node/register',
       '--format',
-      '"@saucelabs/cucumber-reporter":"sauce-test-report.json"',
+      '"@saucelabs/cucumber-reporter":"cucumber.log"',
       '--format-options',
       '{"upload":false,"build":"mybuild","outputFile":"/project/assets/sauce-test-report.json"}',
     ]);

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -13,6 +13,9 @@ describe('buildArgs', () => {
       suite: {
         options: {
           paths: ['features/test.feature'],
+          formatOptions: {
+            build: 'mybuild',
+          },
         },
       },
     };
@@ -28,7 +31,7 @@ describe('buildArgs', () => {
       '--format',
       '"@saucelabs/cucumber-reporter":"sauce-test-report.json"',
       '--format-options',
-      '{"upload":false,"outputFile":"/project/assets/sauce-test-report.json"}',
+      '{"upload":false,"build":"mybuild","outputFile":"/project/assets/sauce-test-report.json"}',
     ]);
   });
 });

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -66,6 +66,12 @@ describe('normalizeFormat', () => {
     ).toBe(`"file://formatter/implementation":"/project/assets/report.json"`);
   });
 
+  it('should throw an error for an invalid file path type', () => {
+    expect(() => {
+      normalizeFormat(`file://formatter/implementation:report.json`, assetDir);
+    }).toThrow('Invalid format setting detected');
+  });
+
   it('should return simple strings as-is', () => {
     expect(normalizeFormat(`"usage"`, assetDir)).toBe('"usage"');
     expect(normalizeFormat(`usage`, assetDir)).toBe('usage');

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -69,7 +69,7 @@ describe('normalizeFormat', () => {
   it('should throw an error for an invalid file path type', () => {
     expect(() => {
       normalizeFormat(`file://formatter/implementation:report.json`, assetDir);
-    }).toThrow('Invalid format setting detected');
+    }).toThrow('Ambiguous colon usage detected');
   });
 
   it('should return simple strings as-is', () => {

--- a/tests/unit/src/cucumber-runner.spec.js
+++ b/tests/unit/src/cucumber-runner.spec.js
@@ -66,6 +66,15 @@ describe('normalizeFormat', () => {
     ).toBe(`"html":"file:///tmp/formatter/report.html"`);
   });
 
+  it('should normalize format with file path type', () => {
+    expect(
+      normalizeFormat(
+        `"file://formatter/implementation":"report.json"`,
+        assetDir,
+      ),
+    ).toBe(`"file://formatter/implementation":"/project/assets/report.json"`);
+  });
+
   it('should return simple strings as-is', () => {
     expect(normalizeFormat(`"usage"`, assetDir)).toBe('"usage"');
     expect(normalizeFormat(`usage`, assetDir)).toBe('usage');


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Cucumber is transitioning to a quoted format for type and path configurations, deprecating unquoted formats. Our current implementation does not support parsing the quoted format. This PR resolves the issue by adding support for quoted format parsing. Stop supporting `file://C:\custom\formatter` pattern as it's ambiguous to proceed the input and hard to understand the error message. Docs will also be addressed.

macOS:
✅ Cucumber@11: https://app.saucelabs.com/tests/01f4f809b8b14bb5a61f6fa87a5775f0
✅ Cucumber@9.6.0: https://app.saucelabs.com/tests/60e70b1f1b6443618c35cf7ba5308651
✅ Cucumber@9.4.0: https://app.saucelabs.com/tests/5e2753cee2cb494fbf04eff46bc48789

Windows:
✅ Cucumber@9.6.0: https://app.saucelabs.com/tests/3a904aab3e4a4ced815cbbdb754a83db
✅ Cucumber@9.4.0: https://app.saucelabs.com/tests/9f4ff5141f054ab1bcff1886fe8446f2
⛔  Cucumber@10 and Cucumber@11 failed due to our known issue. https://app.saucelabs.com/tests/12193fa2d3364482bde9652a9a5bad57

Note: The file URI pattern in the path field, such as `"html":"file://output_file"`, is not supported. The file will fail to generate without any error or warning.

I'll also add docs for the format patterns.